### PR TITLE
reconnect when the introspector is not ready

### DIFF
--- a/accel/kvm/kvm-all.c
+++ b/accel/kvm/kvm-all.c
@@ -104,7 +104,6 @@ struct KVMState
 #endif
     KVMMemoryListener memory_listener;
     QLIST_HEAD(, KVMParkedVcpu) kvm_parked_vcpus;
-    const char *introspected_id;
 };
 
 KVMState *kvm_state;
@@ -133,48 +132,13 @@ static const KVMCapabilityInfo kvm_required_capabilites[] = {
     KVM_CAP_LAST_INFO
 };
 
-static void connect_introspection(const char *id, Error **errp)
-{
-    KVMState *s;
-    int ret;
-    struct kvm_introspection h = {};
-    Object *obj;
-
-    /* TODO: how do we reconnect? */
-    /* TODO: proper capabilities. */
-
-    obj = object_resolve_path_component(object_get_objects_root(), id);
-    if (!obj) {
-        error_setg(errp, "introspection object '%s' not found", id);
-        return;
-    }
-
-    h.fd = vm_introspection_fd(obj, &h.commands, &h.events, errp);
-
-    if (h.fd == -1) {
-        error_setg(errp, "introspection handshake failed");
-        return;
-    }
-
-    s = KVM_STATE(current_machine->accelerator);
-
-    ret = kvm_vm_ioctl(s, KVM_INTROSPECTION, &h);
-    close(h.fd);
-
-    if (ret < 0) {
-        error_setg(errp, "handing over the introspection fd failed: %d",
-                   -errno);
-    }
-}
-
 void kvm_configure(QemuOpts *opts, Error **errp)
 {
     KVMState *s = KVM_STATE(current_machine->accelerator);
     const char *i = qemu_opt_get(opts, "introspection");
 
     if (i) {
-        s->introspected_id = i;
-        connect_introspection(i, errp);
+        vm_introspection_connect(s, i, errp);
     }
 }
 

--- a/accel/kvm/vm-introspection.c
+++ b/accel/kvm/vm-introspection.c
@@ -207,7 +207,7 @@ static void chr_event(void *opaque, int event)
     }
     case CHR_EVENT_CLOSED:
         if (i->watch) {
-            info_report("introspection disconnected");
+            warn_report("introspection disconnected");
             g_source_remove(i->watch);
             i->watch = 0;
         }

--- a/accel/kvm/vm-introspection.c
+++ b/accel/kvm/vm-introspection.c
@@ -199,7 +199,6 @@ static void *reconnect_introspection(void *arg)
         if (err) {
             warn_report_err(err);
         }
-        /* error_free(err); */
     }
 
     i->reconnecting = false;

--- a/chardev/char-socket.c
+++ b/chardev/char-socket.c
@@ -1070,6 +1070,14 @@ char_socket_get_connected(Object *obj, Error **errp)
     return s->connected;
 }
 
+static bool
+char_socket_get_reconnecting(Object *obj, Error **errp)
+{
+    SocketChardev *s = SOCKET_CHARDEV(obj);
+
+    return s->reconnect_time > 0;
+}
+
 static void
 char_socket_get_fd(Object *obj, Visitor *v, const char *name, void *opaque,
                    Error **errp)
@@ -1106,6 +1114,10 @@ static void char_socket_class_init(ObjectClass *oc, void *data)
                               NULL, NULL, &error_abort);
 
     object_class_property_add_bool(oc, "connected", char_socket_get_connected,
+                                   NULL, &error_abort);
+
+    object_class_property_add_bool(oc, "reconnecting",
+                                   char_socket_get_reconnecting,
                                    NULL, &error_abort);
 
     object_class_property_add(oc, "fd", "int32", char_socket_get_fd,

--- a/include/sysemu/vm-introspection.h
+++ b/include/sysemu/vm-introspection.h
@@ -1,7 +1,7 @@
 /*
  * VM Introspection
  *
- * Copyright (C) 2017 Bitdefender S.R.L.
+ * Copyright (C) 2017-2018 Bitdefender S.R.L.
  *
  * This work is licensed under the terms of the GNU GPL, version 2 or later.
  * See the COPYING file in the top-level directory.
@@ -16,9 +16,9 @@
  * The VMIntrospection object is used to do the handshake with an
  * introspection tool and pass the connection to KVM.
  *
- *  $QEMU -chardev socket,id=chardev0,type=vsock,cid=10,port=1234           \
- *        -object secret,id=key0,data=some                                  \
- *        -object introspection,id=kvmi,chardev=chardev0,key=key0,allow=all \
+ *  $QEMU -chardev socket,id=chardev0,type=vsock,cid=10,port=1234,reconnect=1 \
+ *        -object secret,id=key0,data=some                                    \
+ *        -object introspection,id=kvmi,chardev=chardev0,key=key0             \
  *        -accel kvm,introspection=kvmi
  *
  */
@@ -38,16 +38,11 @@ typedef struct VMIntrospection_handshake {
 } VMIntrospection_handshake;
 
 /**
- * vm_introspection_fd:
- * @obj: the introspection object
- * @commands: allowed commands mask
- * @events: allowed events mask
+ * vm_introspection_connect:
+ * @s: the KVM context (used with kvm_vm_ioctl)
+ * @id: the introspection object name
  * @errp: error object handle
- *
- * Returns: the file handle on success or -1 on failure.
  */
-extern int vm_introspection_fd(Object *obj, uint32_t *commands,
-                               uint32_t *events, Error **errp);
+extern void vm_introspection_connect(KVMState *s, const char *id, Error **errp);
 
 #endif
-


### PR DESCRIPTION
QEMU starts a client connection to the introspector and stops if it
cannot connect. This is the "-chardev socket,..." part, before the start
of the introspection handshake (vm_introspection_connect()). Adding
',reconnect=N' (N>0) to the chardev object will let the code flow
reach the vm_introspection_connect() function, which will connect to
the introspector or start a thread to do it when the socket connection
is done.

However, when using the reconnect argument while the introspector is
ready, by the time vm_introspection_connect() is executed, the socket
won't be ready and the connection to the introspector will be delayed
with at least 2 seconds and with an warning.

Another ugly thing is that a sleep(2) is used when waiting for the
socket connection. The qemu_chr_fe_wait_connected() function doesn't
wait because the object used for waiting is not yet created.

Besides this, the patch does a couple of other things:
 - moves the introspection code from kvm-all.c to vm-introspection.c
 - uses better error reporting
 - apply some code refactoring
