### PR TITLE
Add support for the new remote memory mapping implementation

### DIFF
--- a/accel/kvm/Makefile.objs
+++ b/accel/kvm/Makefile.objs
@@ -1,2 +1,3 @@
 obj-y += kvm-all.o
+obj-y += vmi.o
 obj-$(call lnot,$(CONFIG_SEV)) += sev-stub.o

--- a/accel/kvm/Makefile.objs
+++ b/accel/kvm/Makefile.objs
@@ -1,3 +1,4 @@
 obj-y += kvm-all.o
 obj-y += vmi.o
+obj-y += mem-introspection.o
 obj-$(call lnot,$(CONFIG_SEV)) += sev-stub.o

--- a/accel/kvm/Makefile.objs
+++ b/accel/kvm/Makefile.objs
@@ -1,4 +1,5 @@
 obj-y += kvm-all.o
 obj-y += vmi.o
+obj-y += mem-source.o
 obj-y += mem-introspection.o
 obj-$(call lnot,$(CONFIG_SEV)) += sev-stub.o

--- a/accel/kvm/mem-introspection.c
+++ b/accel/kvm/mem-introspection.c
@@ -1,0 +1,947 @@
+/*
+ * VM Introspection
+ *
+ * Copyright (C) 2020 Bitdefender S.R.L.
+ *
+ * This work is licensed under the terms of the GNU GPL, version 2 or later.
+ * See the COPYING file in the top-level directory.
+ */
+
+#include "qemu/osdep.h"
+#include "qemu/error-report.h"
+#include "qemu/thread.h"
+
+#include "qapi/error.h"
+#include "qom/object_interfaces.h"
+
+#include "hw/hw.h"
+#include "hw/mem/pc-dimm.h"
+#include "hw/qdev-properties.h"
+
+#include "io/channel.h"
+#include "io/channel-file.h"
+
+#include "sysemu/sysemu.h"
+#include "sysemu/hostmem.h"
+#include "sysemu/hostmem-remmap.h"
+#include "sysemu/reset.h"
+#include "sysemu/kvm.h"
+
+#include "chardev/char.h"
+#include "chardev/char-fe.h"
+
+#include <linux/remote_mapping.h>
+#include <sys/ioctl.h>
+
+#include "mem-introspection.h"
+
+typedef struct ProcIntrospectionState ProcIntrospectionState;
+
+#define TYPE_PROC_INTROSPECTION "proc-introspection"
+#define PROC_INTROSPECTION(obj) \
+    OBJECT_CHECK(ProcIntrospectionState, (obj), TYPE_PROC_INTROSPECTION)
+
+// QIOChannelFunc
+static gboolean proc_introspection_qio(QIOChannel *ioc, GIOCondition condition, gpointer data);
+
+static void mem_introspection_domain_shutdown(MemIntrospectionState *mi,
+                                              ProcIntrospectionState *pi,
+                                              Error **errp);
+
+/*
+ * Holds the introspection context for a single process.
+ * Every introspected memory region creates a hot-pluggable device.
+ *
+ * The fd belongs to this object and can be closed at any time.
+ * The file will close when the last memory obtained by mmap()
+ * will be munmap()-ped. That's the memory backend's problem.
+ */
+typedef struct ProcIntrospectionState {
+    /*< private >*/
+    DeviceState parent_obj;
+
+    /*< public >*/
+    QemuUUID uuid;
+    int pidfd;
+    int memfd;
+
+    QIOChannel *qio;        /* domain shutdown event handler */
+    guint src_id;
+
+    bool introspected;      /* state variables... */
+    bool shutdown;          /* ...must be modified under introspection lock */
+
+    GHashTable *gpaHash;
+
+} ProcIntrospectionState;
+
+static void proc_introspection_start(ProcIntrospectionState *pi)
+{
+    info_report("%s: pi %p, domain "UUID_FMT, __func__, pi, UUID_ARG(&pi->uuid));
+
+    pi->introspected = true;
+}
+
+static uint64_t proc_introspection_map(ProcIntrospectionState *pi,
+                                       uint64_t gpa, uint64_t size, uint64_t min,
+                                       Error **errp)
+{
+    Object *hostmem;
+    Object *dimm;
+    uint64_t local_gpa = -1;
+
+    info_report("%s: pi %p, domain "UUID_FMT", gpa %lx, size %lx", __func__,
+        pi, UUID_ARG(&pi->uuid), gpa, size);
+
+    hostmem = object_new("memory-backend-remote-mapping");
+
+    // set hostmem properties
+    object_property_set_int(hostmem, pi->memfd, "fd", errp);
+    object_property_set_int(hostmem, size, "size", errp);
+    object_property_set_int(hostmem, gpa, "offset", errp);
+    object_property_set_int(hostmem, min, "align", errp);
+
+    /* complete hostmem => mmap() */
+    user_creatable_complete(USER_CREATABLE(hostmem), errp);
+
+    /* memory allocation in @hostmem may fail */
+    if (*errp)
+        goto out_hostmem;
+
+    dimm = object_new(TYPE_PC_DIMM);
+
+    /* set @dimm as child of machine */
+    gchar *chldprop = g_strdup_printf("%p", dimm);
+    object_property_add_child(container_get(qdev_get_machine(), "/remote-map"), chldprop, dimm, errp);
+    g_free(chldprop);
+
+    /* object_property_add_child() can fail if property already exists */
+    if (*errp)
+        goto out_dimm_noparent;
+
+    /* set @hostmem as child of @dimm */
+    object_property_add_child(dimm, "hostmem", hostmem, errp);
+
+    /* link @dimm to @hostmem - this increments hostmem ref count */
+    object_property_set_link(dimm, hostmem, PC_DIMM_MEMDEV_PROP, errp);
+
+    object_property_set_bool(dimm, true, "realized", errp);
+    if (*errp)
+        goto out_dimm;
+
+    // reference this @dimm by GPA
+    local_gpa = object_property_get_uint(dimm, PC_DIMM_ADDR_PROP, errp);
+    g_hash_table_insert(pi->gpaHash, GINT_TO_POINTER(local_gpa), dimm);
+    info_report("%s: local gpa %lx", __func__, local_gpa);
+
+    object_unref(dimm);             /* usage reference */
+    object_unref(hostmem);          /* usage reference */
+
+    return local_gpa;
+
+out_dimm:
+    object_unparent(dimm);          /* will drag hostmem with it */
+out_dimm_noparent:
+    object_unref(dimm);             /* usage reference */
+out_hostmem:
+    object_unref(hostmem);          /* usage reference */
+
+    return -1;
+}
+
+static void proc_introspection_unmap(ProcIntrospectionState *pi,
+                                     uint64_t gpa, Error **errp)
+{
+    Object *dimm;
+
+    info_report("%s: pi %p, domain "UUID_FMT", local gpa %lx", __func__,
+        pi, UUID_ARG(&pi->uuid), gpa);
+
+    dimm = g_hash_table_lookup(pi->gpaHash, GINT_TO_POINTER(gpa));
+    if (!dimm) {
+        warn_report("remote mapped DIMM @ %lx not present", gpa);
+    } else {
+        g_hash_table_remove(pi->gpaHash, GINT_TO_POINTER(gpa));
+        qdev_unplug(DEVICE(dimm), errp);
+    }
+}
+
+static bool proc_introspection_remap(ProcIntrospectionState *pi,
+                                     uint64_t gpa, Error **errp)
+{
+    Object *dimm;
+    HostMemoryBackendRM *backend;
+
+    info_report("%s: pi %p, domain "UUID_FMT", local gpa %lx", __func__,
+        pi, UUID_ARG(&pi->uuid), gpa);
+
+    dimm = g_hash_table_lookup(pi->gpaHash, GINT_TO_POINTER(gpa));
+    if (!dimm) {
+        error_setg(errp, "Invalid address %lx", gpa);
+        return false;
+    }
+
+    backend = MEMORY_BACKEND_RM(object_property_get_link(dimm, PC_DIMM_MEMDEV_PROP, errp));
+    assert(backend);
+
+    remote_memory_backend_remap(backend, errp);
+    if (*errp)
+        return false;
+
+    return true;
+}
+
+/*
+ * Mark the introspection as ended. This must be called under mi->intro_lock.
+ * By the time this function is called, all children + associations must have
+ * been removed, either by request or by reset.
+ */
+static void proc_introspection_end(ProcIntrospectionState *pi)
+{
+    info_report("%s: pi %p, domain "UUID_FMT, __func__, pi, UUID_ARG(&pi->uuid));
+
+    assert(g_hash_table_size(pi->gpaHash) == 0);
+
+    pi->introspected = false;
+}
+
+/* Work on the object state. This must be called under mi->intro_lock. */
+static void proc_introspection_shutdown(ProcIntrospectionState *pi)
+{
+    info_report("%s: pi %p, domain "UUID_FMT, __func__, pi, UUID_ARG(&pi->uuid));
+
+    pi->shutdown = true;
+}
+
+// constructor
+static void proc_introspection_instance_init(Object *obj)
+{
+    ProcIntrospectionState *pi = PROC_INTROSPECTION(obj);
+
+    info_report("%s: pi %p", __func__, pi);
+
+    pi->pidfd = -1;
+    pi->memfd = -1;
+    pi->gpaHash = g_hash_table_new(g_direct_hash, g_direct_equal);
+}
+
+static void proc_introspection_realize(DeviceState *dev, Error **errp)
+{
+    ProcIntrospectionState *pi = PROC_INTROSPECTION(dev);
+
+    info_report("%s: pi %p, domain "UUID_FMT, __func__,
+        pi, UUID_ARG(&pi->uuid));
+
+    /* properties have been assigned, fd should be open */
+    if (fcntl(pi->memfd, F_GETFL) == -1 && errno == EBADF) {
+        pi->memfd = -1;
+        error_setg_errno(errp, errno, "Can't do mappings");
+    }
+
+    /* poll waiting for the pidfd to close */
+    pi->qio = QIO_CHANNEL(qio_channel_file_new_fd(pi->pidfd));
+    pi->src_id = qio_channel_add_watch(pi->qio, G_IO_IN,
+        proc_introspection_qio, pi, NULL);
+}
+
+/* Unrealization will be done as result of unparenting. */
+static void proc_introspection_unrealize(DeviceState *dev, Error **errp)
+{
+    ProcIntrospectionState *pi = PROC_INTROSPECTION(dev);
+
+    info_report("%s: pi %p, domain "UUID_FMT, __func__,
+        pi, UUID_ARG(&pi->uuid));
+
+    if (pi->pidfd != -1) {
+        if (close(pi->pidfd))
+            error_setg_errno(errp, errno, "%s: closing fd %d failed",
+                __func__, pi->pidfd);
+        pi->pidfd = -1;
+    }
+
+    if (pi->memfd != -1) {
+        if (close(pi->memfd))
+            error_setg_errno(errp, errno, "%s: closing fd %d failed",
+                __func__, pi->memfd);
+        pi->memfd = -1;
+    }
+
+    if (pi->src_id != 0) {
+        g_source_remove(pi->src_id);
+        pi->src_id = 0;
+    }
+
+    if (pi->qio) {
+        object_unref(OBJECT(pi->qio));
+        pi->qio = NULL;
+    }
+}
+
+static gboolean reset_ghr_func(gpointer key, gpointer value, gpointer user_data)
+{
+    PCDIMMDevice *dimm = (PCDIMMDevice *)value;
+    HotplugHandler *hotplug_ctrl;
+    Error *local_err = NULL;
+
+    info_report("%s: unplugging DIMM @ %lx", __func__, dimm->addr);
+
+    /* synchronously remove the slot */
+    hotplug_ctrl = qdev_get_hotplug_handler(DEVICE(dimm));
+    hotplug_handler_unplug(hotplug_ctrl, DEVICE(dimm), &local_err);
+
+    object_unparent(OBJECT(dimm));
+
+    if (local_err)
+        warn_report_err(local_err);
+
+    return TRUE;
+}
+
+/*
+ * In case of a real machine reset during introspection, this call comes on the
+ * main thread, so there is no need no take qemu_global_mutex.
+ * Also a reset is triggered on realization, but the gpaHash should be empty.
+ */
+static void proc_introspection_reset(DeviceState *dev)
+{
+    ProcIntrospectionState *pi = PROC_INTROSPECTION(dev);
+
+    info_report("%s: pi %p, domain "UUID_FMT, __func__,
+        pi, UUID_ARG(&pi->uuid));
+
+    /* remove all children -> dimms */
+    g_hash_table_foreach_remove(pi->gpaHash, reset_ghr_func, NULL);
+    pi->introspected = false;
+}
+
+// destructor
+static void proc_introspection_instance_finalize(Object *obj)
+{
+    ProcIntrospectionState *pi = PROC_INTROSPECTION(obj);
+
+    info_report("%s: pi %p, domain "UUID_FMT, __func__,
+        pi, UUID_ARG(&pi->uuid));
+
+    g_hash_table_destroy(pi->gpaHash);
+}
+
+static Property proc_introspection_properties[] = {
+    DEFINE_PROP_UUID("uuid", ProcIntrospectionState, uuid),
+    DEFINE_PROP_INT32("pidfd", ProcIntrospectionState, pidfd, -1),
+    DEFINE_PROP_INT32("memfd", ProcIntrospectionState, memfd, -1),
+    DEFINE_PROP_END_OF_LIST(),
+};
+
+static void proc_introspection_class_init(ObjectClass *oc, void *data)
+{
+    DeviceClass *dc = DEVICE_CLASS(oc);
+
+    dc->realize = proc_introspection_realize;
+    dc->unrealize = proc_introspection_unrealize;
+    dc->reset = proc_introspection_reset;
+    dc->props = proc_introspection_properties;
+    dc->desc = "Domain introspection device";
+}
+
+static const TypeInfo proc_introspection_info = {
+    .name = TYPE_PROC_INTROSPECTION,
+    .parent = TYPE_DEVICE,
+
+    .instance_size = sizeof(ProcIntrospectionState),
+    .instance_init = proc_introspection_instance_init,
+    .instance_finalize = proc_introspection_instance_finalize,
+
+    .class_init = proc_introspection_class_init,
+};
+
+
+
+
+
+
+
+
+typedef struct MemIntrospectionState {
+    /* private */
+    Object parent_obj;
+
+    /* public */
+    char *chardev;
+    CharBackend chr;
+    Notifier machine_ready;
+
+    QemuMutex intro_lock;
+
+    GHashTable *ready;          /* uuid -> pi */
+    GHashTable *introspected;   /* uuid -> pi */
+    GHashTable *gpaHash;        /* gpa -> pi */
+} MemIntrospectionState;
+
+static ProcIntrospectionState *
+proc_introspection_alloc(MemIntrospectionState *mi,
+    const QemuUUID *uuid, int fds[2], Error **errp)
+{
+    Object *pi;
+
+    info_report("%s: domain "UUID_FMT, __func__, UUID_ARG(uuid));
+
+    pi = object_new(TYPE_PROC_INTROSPECTION);
+
+    /* set @pi as child of @mi */
+    gchar *chldprop = g_strdup_printf("dom-"UUID_FMT, UUID_ARG(uuid));
+    object_property_add_child(OBJECT(mi), chldprop, pi, errp);
+    g_free(chldprop);
+
+    // TODO: there is no func for setting UUID, work-around this
+    ProcIntrospectionState *pi_dev = PROC_INTROSPECTION(pi);
+    memcpy(&pi_dev->uuid, uuid, sizeof(*uuid));
+
+    /* pass the fds tp @pi - this object will close the fds */
+    object_property_set_int(pi, fds[0], "pidfd", errp);
+    object_property_set_int(pi, fds[1], "memfd", errp);
+
+    /* link back to owner @mi */
+    object_property_add_const_link(pi, "introspection", OBJECT(mi), errp);
+
+    /* trigger initialization of @pi */
+    object_property_set_bool(pi, true, "realized", errp);
+
+    /* insert in ready list */
+    g_hash_table_insert(mi->ready, qemu_uuid_dup(uuid), pi);
+
+    return PROC_INTROSPECTION(pi);
+}
+
+// QIOChannelFunc for @pi
+static gboolean proc_introspection_qio(QIOChannel *ioc, GIOCondition condition, gpointer data)
+{
+    ProcIntrospectionState *pi = PROC_INTROSPECTION(data);
+    MemIntrospectionState *mi;
+    Error *local_err = NULL;
+
+    info_report("%s: domain "UUID_FMT" shutting down", __func__, UUID_ARG(&pi->uuid));
+
+    pi->src_id = 0; /* this source will auto-remove */
+
+    mi = MEM_INTROSPECTION(object_property_get_link(OBJECT(pi), "introspection", &local_err));
+    assert(mi);
+    mem_introspection_domain_shutdown(mi, pi, &local_err);
+
+    if (local_err)
+        warn_report_err(local_err);
+
+    return G_SOURCE_REMOVE;
+}
+
+static ProcIntrospectionState *
+proc_introspection_lookup_ready(MemIntrospectionState *mi, const QemuUUID *uuid)
+{
+    Object *pi;
+
+    pi = g_hash_table_lookup(mi->ready, uuid);
+    if (pi)
+        object_ref(pi);
+
+    return PROC_INTROSPECTION(pi);
+}
+
+static void
+move_to_introspected(MemIntrospectionState *mi, ProcIntrospectionState *pi,  Error **errp)
+{
+    g_hash_table_remove(mi->ready, &pi->uuid);
+    g_hash_table_insert(mi->introspected, qemu_uuid_dup(&pi->uuid), pi);
+}
+
+static ProcIntrospectionState *
+proc_introspection_lookup_introspected(MemIntrospectionState *mi, const QemuUUID *uuid)
+{
+    Object *pi;
+
+    pi = g_hash_table_lookup(mi->introspected, uuid);
+    if (pi)
+        object_ref(pi);
+
+    return PROC_INTROSPECTION(pi);
+}
+
+static void
+move_to_ready(MemIntrospectionState *mi, ProcIntrospectionState *pi,  Error **errp)
+{
+    g_hash_table_remove(mi->introspected, &pi->uuid);
+    g_hash_table_insert(mi->ready, qemu_uuid_dup(&pi->uuid), pi);
+}
+
+// entry point - domain ready for introspection
+static void mem_introspection_domain_ready(MemIntrospectionState *mi,
+                                           const QemuUUID *uuid, int fds[2],
+                                           Error **errp)
+{
+    ProcIntrospectionState *pi;
+
+    info_report("%s: mi %p, domain "UUID_FMT", pidfd %d, memfd %d", __func__,
+        mi, UUID_ARG(uuid), fds[0], fds[1]);
+
+    qemu_mutex_lock(&mi->intro_lock);
+
+    /*
+     * this event and mem_introspection_dev_shutdown() come from 2 different
+     * sources, but should be serialized on the same thread
+     */
+    pi = proc_introspection_lookup_ready(mi, uuid);
+    if (pi) {
+        /* this happens when introspection reconnects */
+        error_setg(errp, "Domain "UUID_FMT" already present", UUID_ARG(uuid));
+        close(fds[0]);
+        close(fds[1]);
+        goto out;
+    }
+
+    /* allocate the @pi for the current session */
+    pi = proc_introspection_alloc(mi, uuid, fds, errp);
+    object_unref(OBJECT(pi));
+
+out:
+    qemu_mutex_unlock(&mi->intro_lock);
+
+    info_report("%s: -", __func__);
+}
+
+// entry point - introspection start
+void mem_introspection_start(MemIntrospectionState *mi, const QemuUUID *uuid,
+                             CPUState *cs, Error **errp)
+{
+    ProcIntrospectionState *pi;
+
+    info_report("%s: mi %p, domain "UUID_FMT, __func__, mi, UUID_ARG(uuid));
+
+    qemu_mutex_lock(&mi->intro_lock);
+
+    /* mem_introspection_start() should come after mem_introspection_domain_ready() */
+    pi = proc_introspection_lookup_ready(mi, uuid);
+    if (!pi) {
+        error_setg(errp, "Domain "UUID_FMT" not ready", UUID_ARG(uuid));
+        goto out;
+    }
+
+    proc_introspection_start(pi);
+    move_to_introspected(mi, pi, errp);
+
+    object_unref(OBJECT(pi));
+
+out:
+    qemu_mutex_unlock(&mi->intro_lock);
+
+    info_report("%s: -", __func__);
+}
+
+// entry point - map request
+void mem_introspection_map(MemIntrospectionState *mi, const QemuUUID *uuid,
+                           uint64_t gpa, uint64_t size, uint64_t min,
+                           CPUState *cs, Error **errp)
+{
+    ProcIntrospectionState *pi;
+    uint64_t local_gpa = -1;
+
+    info_report("%s: mi %p, domain "UUID_FMT", gpa %lx, size %lx", __func__,
+        mi, UUID_ARG(uuid), gpa, size);
+
+    qemu_mutex_lock(&mi->intro_lock);
+
+    pi = proc_introspection_lookup_introspected(mi, uuid);
+    if (!pi) {
+        qemu_mutex_unlock(&mi->intro_lock);
+        error_setg(errp, "Domain "UUID_FMT" not introspected", UUID_ARG(uuid));
+        goto out;
+    }
+
+    qemu_mutex_unlock(&mi->intro_lock);
+
+    qemu_mutex_lock_iothread();
+
+    local_gpa = proc_introspection_map(pi, gpa, size, min, errp);
+    if (local_gpa != -1)
+        g_hash_table_insert(mi->gpaHash, GINT_TO_POINTER(local_gpa), pi);
+
+    qemu_mutex_unlock_iothread();
+
+    object_unref(OBJECT(pi));
+
+out:
+    /* adjust local_gpa for ioctl() */
+    if (*errp)
+        local_gpa = error_get_errno(*errp) ? -error_get_errno(*errp) : -EINVAL;
+
+    kvm_vcpu_ioctl(cs, KVM_INTROSPECTION_MAP, local_gpa);
+
+    info_report("%s: -", __func__);
+}
+
+// entry point - unmap request
+void mem_introspection_unmap(MemIntrospectionState *mi, const QemuUUID *uuid,
+                             uint64_t gpa, CPUState *cs, Error **errp)
+{
+    ProcIntrospectionState *pi;
+
+    info_report("%s: mi %p, domain "UUID_FMT", local gpa %lx", __func__,
+        mi, UUID_ARG(uuid), gpa);
+
+    qemu_mutex_lock(&mi->intro_lock);
+
+    pi = proc_introspection_lookup_introspected(mi, uuid);
+    if (!pi) {
+        qemu_mutex_unlock(&mi->intro_lock);
+        error_setg(errp, "Domain "UUID_FMT" not introspected", UUID_ARG(uuid));
+        goto out;
+    }
+
+    qemu_mutex_unlock(&mi->intro_lock);
+
+    qemu_mutex_lock_iothread();
+
+    g_hash_table_remove(mi->gpaHash, GINT_TO_POINTER(gpa));
+    proc_introspection_unmap(pi, gpa, errp);
+
+    qemu_mutex_unlock_iothread();
+
+    object_unref(OBJECT(pi));
+
+out:
+    info_report("%s: -", __func__);
+}
+
+// entry point - remap request
+bool mem_introspection_remap(MemIntrospectionState *mi, uint64_t gpa,
+                             CPUState *cs, Error **errp)
+{
+    ProcIntrospectionState *pi;
+    bool result = false;
+
+    info_report("%s: mi %p, local gpa %lx", __func__, mi, gpa);
+
+    gpa = kvm_start_of_slot(cs->kvm_state, gpa);
+
+    pi = g_hash_table_lookup(mi->gpaHash, GINT_TO_POINTER(gpa));
+    if (!pi) {
+        error_setg(errp, "Address %lx does not belong to introspector", gpa);
+        goto out;
+    }
+
+    result = proc_introspection_remap(pi, gpa, errp);
+
+out:
+    info_report("%s: -", __func__);
+
+    return result;
+}
+
+// entry point - introspection end
+void mem_introspection_end(MemIntrospectionState *mi, const QemuUUID *uuid,
+                           CPUState *cs, Error **errp)
+{
+    ProcIntrospectionState *pi;
+
+    info_report("%s: mi %p, domain "UUID_FMT, __func__, mi, UUID_ARG(uuid));
+
+    qemu_mutex_lock(&mi->intro_lock);
+
+    pi = proc_introspection_lookup_introspected(mi, uuid);
+    if (!pi) {
+        error_setg(errp, "Domain "UUID_FMT" not introspected", UUID_ARG(uuid));
+        goto out;
+    }
+
+    proc_introspection_end(pi);
+
+    if (pi->shutdown) {
+        g_hash_table_remove(mi->introspected, &pi->uuid);
+        object_unparent(OBJECT(pi));
+    }
+    else {
+        /* mem_introspection_shutdown() is yet to arrive */
+        move_to_ready(mi, pi, errp);
+    }
+
+    object_unref(OBJECT(pi));           /* usage reference */
+
+out:
+    qemu_mutex_unlock(&mi->intro_lock);
+
+    info_report("%s: -", __func__);
+}
+
+// entry point - domain shutdown
+static void mem_introspection_domain_shutdown(MemIntrospectionState *mi, ProcIntrospectionState *pi,
+                                              Error **errp)
+{
+    info_report("%s: mi %p, domain "UUID_FMT, __func__, mi, UUID_ARG(&pi->uuid));
+
+    qemu_mutex_lock(&mi->intro_lock);
+
+    proc_introspection_shutdown(pi);
+
+    if (pi->introspected) {
+        /* mem_introspection_end() is yet to arrive */
+    }
+    else {
+        g_hash_table_remove(mi->ready, &pi->uuid);
+        object_unparent(OBJECT(pi));
+    }
+
+    qemu_mutex_unlock(&mi->intro_lock);
+
+    info_report("%s: -", __func__);
+}
+
+static int mem_introspection_reset_helper(Object *child, void *opaque)
+{
+    ProcIntrospectionState *pi = PROC_INTROSPECTION(child);
+
+    device_reset(DEVICE(pi));
+
+    return 0;
+}
+
+static gboolean mem_introspection_reset_ghr(gpointer key, gpointer value, gpointer user_data)
+{
+    ProcIntrospectionState *pi = (ProcIntrospectionState *)value;
+
+    object_unparent(OBJECT(pi));
+
+    return TRUE;
+}
+
+// entry point - reset handler
+static void mem_introspection_reset(void *opaque)
+{
+    MemIntrospectionState *mi = MEM_INTROSPECTION(opaque);
+
+    info_report("%s: mi %p", __func__, mi);
+
+    qemu_mutex_lock(&mi->intro_lock);
+
+    /* this will trigger the @pi to unplug its DIMMs */
+    object_child_foreach(OBJECT(mi), mem_introspection_reset_helper, NULL);
+
+    /*
+     * every @pi child is either ready or introspected
+     * remove (unparent) @pis by looking up the hast tables
+     * at the same time remove them from the hash tables
+     */
+    g_hash_table_foreach_remove(mi->ready, mem_introspection_reset_ghr, NULL);
+    g_hash_table_foreach_remove(mi->introspected, mem_introspection_reset_ghr, NULL);
+
+    qemu_mutex_unlock(&mi->intro_lock);
+
+    info_report("%s: -", __func__);
+}
+
+// hash helpers
+static guint qemu_uuid_hash_func(gconstpointer key)
+{
+    // TODO: for now return the first bytes comprising an int
+    return *(guint *)key;
+    // TODO: use a real hash function if there is one
+}
+
+static gboolean qemu_uuid_equal_func(gconstpointer keya, gconstpointer keyb)
+{
+    if (!memcmp(keya, keyb, sizeof(QemuUUID)))
+        return TRUE;
+
+    return FALSE;
+}
+
+static void qemu_uuid_key_destroy(gpointer key)
+{
+    g_free(key);
+}
+
+// constructor
+static void mem_introspection_instance_init(Object *obj)
+{
+    MemIntrospectionState *mi = MEM_INTROSPECTION(obj);
+
+    info_report("%s: mi %p", __func__, mi);
+
+    qemu_mutex_init(&mi->intro_lock);
+
+    mi->ready = g_hash_table_new_full(qemu_uuid_hash_func,
+        qemu_uuid_equal_func, qemu_uuid_key_destroy, NULL);
+    mi->introspected = g_hash_table_new_full(qemu_uuid_hash_func,
+        qemu_uuid_equal_func, qemu_uuid_key_destroy, NULL);
+    mi->gpaHash = g_hash_table_new(g_direct_hash, g_direct_equal);
+}
+
+// destructor
+static void mem_introspection_instance_finalize(Object *obj)
+{
+    MemIntrospectionState *mi = MEM_INTROSPECTION(obj);
+
+    info_report("%s: mi %p", __func__, mi);
+
+    qemu_chr_fe_deinit(&mi->chr, true);
+    qemu_unregister_reset(mem_introspection_reset, mi);
+
+    qemu_mutex_destroy(&mi->intro_lock);
+
+    g_hash_table_destroy(mi->ready);
+    g_hash_table_destroy(mi->introspected);
+    g_hash_table_destroy(mi->gpaHash);
+
+    g_free(mi->chardev);
+}
+
+static int mem_chardev_can_read(void *opaque)
+{
+    return (int) sizeof(MemIntrospectionPkt);
+}
+
+static void mem_chardev_read(void *opaque, const uint8_t *buf, int size)
+{
+    MemIntrospectionState *mi = opaque;
+    MemIntrospectionPkt *data = (MemIntrospectionPkt *) buf;
+    Error *local_err = NULL;
+    gboolean ack = TRUE;
+    int fds[2];
+    int result;
+
+    assert(size == sizeof(MemIntrospectionPkt));
+
+    result = qemu_chr_fe_get_msgfds(&mi->chr, fds, 2);
+    if (result == -1) {
+        error_setg(&local_err, "%s: failed receiving fds", __func__);
+        goto out;
+    }
+
+    //info_report("%s: got fd %d from machine "UUID_FMT, __func__, fd, UUID_ARG(&data->dom_id));
+
+    mem_introspection_domain_ready(mi, &data->dom_id, fds, &local_err);
+
+out:
+    if (local_err) {
+        warn_report_err(local_err);
+        ack = FALSE;
+    }
+
+    qemu_chr_fe_write(&mi->chr, (const uint8_t *)&ack, (int)sizeof(ack));
+}
+
+static void mem_introspection_machine_ready(Notifier *notifier, void *data)
+{
+    MemIntrospectionState *mi = container_of(notifier, MemIntrospectionState, machine_ready);
+    Error *local_err = NULL;
+    Chardev *chr;
+
+    info_report("%s: mi %p", __func__, mi);
+
+    // chardevs are added later to tree - WHY ?
+    chr = qemu_chr_find(mi->chardev);
+    if (!chr) {
+        error_setg(&local_err, "Chardev '%s' not found", mi->chardev);
+        goto out;
+    }
+
+    // init chardev front-end
+    if (!qemu_chr_fe_init(&mi->chr, chr, &local_err)) {
+        // errp already filled by qemu_chr_fe_init()
+        goto out;
+    }
+
+    qemu_chr_fe_set_handlers(&mi->chr, mem_chardev_can_read, mem_chardev_read,
+                             NULL, NULL, mi, NULL, true);
+
+out:
+    if (local_err)
+        warn_report_err(local_err);
+}
+
+// user creatable
+static void mem_introspection_complete(UserCreatable *uc, Error **errp)
+{
+    MemIntrospectionState *mi = MEM_INTROSPECTION(uc);
+
+    info_report("%s: mi %p", __func__, mi);
+
+    if (!mi->chardev) {
+        error_setg(errp, "Chardev ID needed for receiving memory info");
+        return;
+    }
+
+    // chardevs are added later to tree
+    mi->machine_ready.notify = mem_introspection_machine_ready;
+    qemu_add_machine_init_done_notifier(&mi->machine_ready);
+
+    qemu_register_reset(mem_introspection_reset, mi);
+}
+
+// user creatable
+static bool mem_introspection_can_be_deleted(UserCreatable *uc)
+{
+    MemIntrospectionState *mi = MEM_INTROSPECTION(uc);
+    bool can;
+
+    info_report("%s: mi %p", __func__, mi);
+
+    qemu_mutex_lock(&mi->intro_lock);
+    can = g_hash_table_size(mi->introspected) != 0;
+    qemu_mutex_unlock(&mi->intro_lock);
+
+    if (!can)
+        warn_report("%s: nope, introspection sessions are running", __func__);
+
+    return can;
+}
+
+static char *mem_introspection_get_chardev(Object *obj, Error **errp)
+{
+    MemIntrospectionState *mp = MEM_INTROSPECTION(obj);
+
+    return g_strdup(mp->chardev);
+}
+
+static void mem_introspection_set_chardev(Object *obj, const char *str, Error **errp)
+{
+    MemIntrospectionState *mp = MEM_INTROSPECTION(obj);
+
+    g_free(mp->chardev);
+    mp->chardev = g_strdup(str);
+}
+
+static void mem_introspection_class_init(ObjectClass *oc, void *data)
+{
+    UserCreatableClass *uc = USER_CREATABLE_CLASS(oc);
+
+    object_class_property_add_str(oc, "chardev",
+        mem_introspection_get_chardev,
+        mem_introspection_set_chardev,
+        &error_abort);
+    object_class_property_set_description(oc, "chardev",
+        "A backend used to communicate memory metadata",
+        &error_abort);
+
+    uc->can_be_deleted = mem_introspection_can_be_deleted;
+    uc->complete = mem_introspection_complete;
+}
+
+static const TypeInfo mem_introspection_info = {
+    .name = TYPE_MEM_INTROSPECTION,
+    .parent = TYPE_OBJECT,
+
+    .instance_size = sizeof(MemIntrospectionState),
+    .instance_init = mem_introspection_instance_init,
+    .instance_finalize = mem_introspection_instance_finalize,
+
+    .class_init = mem_introspection_class_init,
+    .interfaces = (InterfaceInfo[]) {
+        {TYPE_USER_CREATABLE},
+        {}
+    }
+};
+
+static void mem_introspection_register_types(void)
+{
+    type_register_static(&proc_introspection_info);
+    type_register_static(&mem_introspection_info);
+}
+
+type_init(mem_introspection_register_types)

--- a/accel/kvm/mem-introspection.h
+++ b/accel/kvm/mem-introspection.h
@@ -1,0 +1,57 @@
+/*
+ * VM Introspection
+ *
+ * Copyright (C) 2020 Bitdefender S.R.L.
+ *
+ * This work is licensed under the terms of the GNU GPL, version 2 or later.
+ * See the COPYING file in the top-level directory.
+ */
+
+#ifndef MEM_INTROSPECTION_H
+#define MEM_INTROSPECTION_H
+
+#include "qemu/uuid.h"
+
+#include <linux/kvm.h>
+#include <linux/kvm_para.h>
+
+#define PI_READY_WAIT_MS 3000
+
+typedef struct MemSourceState MemSourceState;
+typedef struct MemIntrospectionState MemIntrospectionState;
+
+#define TYPE_MEM_SOURCE "mem-source"
+#define MEM_SOURCE(obj) \
+    OBJECT_CHECK(MemSourceState, (obj), TYPE_MEM_SOURCE)
+
+#define TYPE_MEM_INTROSPECTION "mem-introspection"
+#define MEM_INTROSPECTION(obj) \
+    OBJECT_CHECK(MemIntrospectionState, (obj), TYPE_MEM_INTROSPECTION)
+
+typedef struct MemIntrospectionPkt {
+    QemuUUID dom_id;
+} MemIntrospectionPkt;
+
+/*
+ * Mem-source interface with VMI. Use according to the following cycle:
+ * mem_source_connect() -> mem_source_disconnect()
+ * Extra calls will be a NOP.
+ */
+typedef void MemSourceConnected(void *opaque);
+void mem_source_connect(MemSourceState *ms, MemSourceConnected *cbk,
+                        void *opaque);
+void mem_source_disconnect(MemSourceState *ms);
+
+/* mem-introspection interface with VCPU */
+void mem_introspection_start(MemIntrospectionState *mi, const QemuUUID *uuid,
+                             CPUState *cs, Error **errp);
+void mem_introspection_map(MemIntrospectionState *mi, const QemuUUID *uuid,
+                           uint64_t gpa, uint64_t size, uint64_t min, CPUState *cs, Error **errp);
+void mem_introspection_unmap(MemIntrospectionState *mi, const QemuUUID *uuid,
+                             uint64_t gpa, CPUState *cs, Error **errp);
+void mem_introspection_end(MemIntrospectionState *mi, const QemuUUID *uuid,
+                           CPUState *cs, Error **errp);
+bool mem_introspection_remap(MemIntrospectionState *mi, uint64_t gpa,
+                             CPUState *cs, Error **errp);
+
+#endif /* MEM_INTROSPECTION_H */

--- a/accel/kvm/mem-source.c
+++ b/accel/kvm/mem-source.c
@@ -1,0 +1,492 @@
+/*
+ * VM Introspection
+ *
+ * Copyright (C) 2020 Bitdefender S.R.L.
+ *
+ * This work is licensed under the terms of the GNU GPL, version 2 or later.
+ * See the COPYING file in the top-level directory.
+ */
+
+#include "qemu/osdep.h"
+#include "qemu/error-report.h"
+#include "qemu/notify.h"
+#include "qemu/thread.h"
+
+#include "exec/memory.h"
+#include "exec/address-spaces.h"
+
+#include "qapi/error.h"
+
+#include "qom/object.h"
+#include "qom/object_interfaces.h"
+
+#include "sysemu/sysemu.h"
+
+#include "chardev/char.h"
+#include "chardev/char-fe.h"
+
+#include <linux/remote_mapping.h>
+#include <sys/ioctl.h>
+#include <sys/syscall.h>
+
+#include "mem-introspection.h"
+
+#define HANDSHAKE_TIMEOUT 5
+static void mem_source_machine_ready(Notifier *notifier, void *data);
+
+struct MemSourceState {
+    /* private */
+    Object parent_obj;
+
+    /* public */
+    char *chardev;
+    CharBackend chr;
+    Notifier machine_ready;
+
+    /* remote mapping */
+    int pidfd;
+    struct rmemfds fds;
+
+    /* handshake logic */
+    GSource *timeout;
+    bool handshake;
+    MemSourceConnected *handshake_complete;
+    void *handshake_complete_ctx;
+
+    MemoryListener mlisten;
+};
+
+/* copied from kvm-all.c */
+static hwaddr kvm_align_section(MemoryRegionSection *section, hwaddr *start)
+{
+    hwaddr size = int128_get64(section->size);
+    hwaddr delta, aligned;
+
+    /* kvm works in page size chunks, but the function may be called
+    with sub-page size and unaligned start address. Pad the start
+    address to next and truncate size to previous page boundary. */
+    aligned = ROUND_UP(section->offset_within_address_space,
+                       qemu_real_host_page_size);
+    delta = aligned - section->offset_within_address_space;
+    *start = aligned;
+    if (delta > size) {
+        return 0;
+    }
+
+    return (size - delta) & qemu_real_host_page_mask;
+}
+
+// memory listener
+static void mlisten_region_add(MemoryListener *listener, MemoryRegionSection *section)
+{
+    MemSourceState *ms = container_of(listener, MemSourceState, mlisten);
+    MemoryRegion *mr = section->mr;
+    void *ram = NULL;
+    hwaddr start_addr, size;
+    struct pidfd_mem_map mreq;
+    int result;
+
+    if (!memory_region_is_ram(mr))
+        return;
+    if (memory_region_is_ram_device(mr))
+        return;             /* only pure memory allowed */
+
+    /* copied from kvm-all.c */
+    size = kvm_align_section(section, &start_addr);
+    if (!size)
+        return;
+
+    /* use aligned delta to align the ram address */
+    ram = memory_region_get_ram_ptr(mr) + section->offset_within_region +
+        (start_addr - section->offset_within_address_space);
+    if (ram == NULL)
+        return;             /* not the region we're interested in */
+
+    //info_report("%s: useful region: phys %lx, size %lx, virt %lx, owner %s",
+    //    __func__, start_addr, size, (long)ram,
+    //    object_get_typename(mr->parent_obj.parent));
+
+    mreq.address = (uint64_t)ram;
+    mreq.offset = start_addr;
+    mreq.size = size;
+
+    result = ioctl(ms->fds.ctl_fd, PIDFD_MEM_MAP, &mreq);
+    if (result)
+        warn_report("%s: failed registering memory region", __func__);
+}
+
+// memory listener
+static void mlisten_region_del(MemoryListener *listener, MemoryRegionSection *section)
+{
+    MemSourceState *ms = container_of(listener, MemSourceState, mlisten);
+    MemoryRegion *mr = section->mr;
+    void *ram = NULL;
+    hwaddr start_addr, size;
+    struct pidfd_mem_unmap ureq;
+    int result;
+
+    if (!memory_region_is_ram(mr))
+        return;
+    if (memory_region_is_ram_device(mr))
+        return;             /* only pure memory allowed */
+
+    /* copied from kvm-all.c */
+    size = kvm_align_section(section, &start_addr);
+    if (!size)
+        return;
+
+    /* use aligned delta to align the ram address */
+    ram = memory_region_get_ram_ptr(mr) + section->offset_within_region +
+        (start_addr - section->offset_within_address_space);
+    if (ram == NULL)
+        return;             /* not the region we're interested in */
+
+    //info_report("%s: useful region: phys %lx, size %lx, virt %lx, owner %s",
+    //    __func__, start_addr, size, (long)ram,
+    //    object_get_typename(mr->parent_obj.parent));
+
+    ureq.offset = start_addr;
+    ureq.size = size;
+
+    result = ioctl(ms->fds.ctl_fd, PIDFD_MEM_UNMAP, &ureq);
+    if (result)
+        warn_report("%s: failed unregistering memory region", __func__);
+}
+
+// constructor
+static void mem_source_instance_init(Object *obj)
+{
+    MemSourceState *ms = MEM_SOURCE(obj);
+
+    info_report("%s: source %p", __func__, ms);
+
+    ms->pidfd = -1;
+    ms->fds.ctl_fd = -1;
+    ms->fds.mem_fd = -1;
+
+    ms->mlisten.region_add = mlisten_region_add;
+    ms->mlisten.region_del = mlisten_region_del;
+    ms->mlisten.priority = 100;
+
+    ms->machine_ready.notify = mem_source_machine_ready;
+}
+
+// destructor
+static void mem_source_instance_finalize(Object *obj)
+{
+    MemSourceState *ms = MEM_SOURCE(obj);
+
+    info_report("%s: source %p", __func__, ms);
+
+    memory_listener_unregister(&ms->mlisten);
+
+    qemu_chr_fe_deinit(&ms->chr, true);
+
+    if (ms->pidfd != -1) {
+        if (close(ms->pidfd))
+            warn_report("Closing pidfd failed: %s", strerror(errno));
+        ms->pidfd = -1;
+    }
+
+    if (ms->fds.ctl_fd != -1) {
+        if (close(ms->fds.ctl_fd))
+            warn_report("Closing control fd failed: %s", strerror(errno));
+        ms->fds.ctl_fd = -1;
+    }
+
+    if (ms->fds.mem_fd != -1) {
+        if (close(ms->fds.mem_fd))
+            warn_report("Closing mapping fd failed: %s", strerror(errno));
+        ms->fds.mem_fd = -1;
+    }
+
+    g_free(ms->chardev);
+}
+
+static void mem_source_send_introspection_ready(MemSourceState *ms, Error **errp)
+{
+    int result;
+    MemIntrospectionPkt data;
+    int fds[2];
+
+    fds[0] = ms->pidfd;
+    fds[1] = ms->fds.mem_fd;
+
+    result = qemu_chr_fe_set_msgfds(&ms->chr, fds, 2);
+    if (result == -1) {
+        error_setg(errp, "Chardev '%s' does not support fd passing", ms->chardev);
+        return;
+    }
+
+    memcpy(&data.dom_id, &qemu_uuid, sizeof(QemuUUID));
+
+    result = qemu_chr_fe_write_all(&ms->chr, (const uint8_t *) &data, sizeof(data));
+    if (result != sizeof(data)) {
+        error_setg(errp, "Failed sending %d bytes", (int)sizeof(data));
+        return;
+    }
+}
+
+static int mem_chardev_can_read(void *opaque)
+{
+    return (int) sizeof(gboolean);
+}
+
+static void mem_chardev_read(void *opaque, const uint8_t *buf, int size)
+{
+    MemSourceState *ms = MEM_SOURCE(opaque);
+    gboolean *ack = (gboolean *)buf;
+
+    assert(size == sizeof(gboolean));
+    info_report("%s: introspection says %s", __func__, *ack == TRUE ? "ACK" : "NACK");
+
+    qemu_chr_fe_disconnect(&ms->chr);
+    ms->handshake = true;
+
+    /* cancel timeout */
+    g_source_destroy(ms->timeout);
+    g_source_unref(ms->timeout);
+    ms->timeout = NULL;
+
+    ms->handshake_complete(ms->handshake_complete_ctx);
+}
+
+// GSourceFunc
+static gboolean mem_handshake_timeout(gpointer user_data)
+{
+    MemSourceState *ms = MEM_SOURCE(user_data);
+
+    info_report("%s: source %p", __func__, ms);
+
+    /* avoid receiving a reply for another message */
+    qemu_chr_fe_disconnect(&ms->chr);
+    ms->handshake = false;
+
+    /* remove timeout source */
+    g_source_unref(ms->timeout);
+    ms->timeout = NULL;
+    return G_SOURCE_REMOVE;
+}
+
+void mem_source_connect(MemSourceState *ms, MemSourceConnected *cbk,
+                        void *opaque)
+{
+    /*
+     * These FDs are set from mem_source_init_introspection().
+     * If not, we assume that the kernel doesn't support remote mapping v2,
+     * but we let the guest continue.
+     */
+    if (ms->fds.ctl_fd == -1 || ms->fds.mem_fd == -1) {
+        warn_report("%s: remote mapping v2 is not supported by the current kernel",
+                    __func__);
+        cbk(opaque);
+        return;
+    }
+
+    if (ms->handshake) {
+        info_report("%s: source %p, already connected, ignored!", __func__, ms);
+        cbk(opaque);
+        return;
+    }
+
+    /*
+     * If this function is called in quick succession before the connection was
+     * established, qemu_chr_fe_connect() will do nothing. Same if the connection
+     * was established.
+     */
+    info_report("%s: source %p, connecting...", __func__, ms);
+    qemu_chr_fe_connect(&ms->chr);
+    ms->handshake_complete = cbk;
+    ms->handshake_complete_ctx = opaque;
+}
+
+void mem_source_disconnect(MemSourceState *ms)
+{
+    info_report("%s: source %p", __func__, ms);
+
+    if (ms->timeout) {
+        g_source_destroy(ms->timeout);
+        g_source_unref(ms->timeout);
+        ms->timeout = NULL;
+    }
+
+    qemu_chr_fe_disconnect(&ms->chr);
+    ms->handshake = false;
+}
+
+static void mem_chardev_event(void *opaque, int event)
+{
+    MemSourceState *ms = MEM_SOURCE(opaque);
+    Error *local_err = NULL;
+
+    info_report("%s: source %p, event %d", __func__, ms, event);
+
+    if (event == CHR_EVENT_OPENED) {
+        mem_source_send_introspection_ready(ms, &local_err);
+
+        ms->timeout = g_timeout_source_new_seconds(HANDSHAKE_TIMEOUT);
+        g_source_set_callback(ms->timeout, mem_handshake_timeout, ms, NULL);
+        g_source_attach(ms->timeout, NULL);
+    }
+
+    if (local_err) {
+        warn_report_err(local_err);
+        qemu_chr_fe_disconnect(&ms->chr);
+    }
+}
+
+// 2nd part of _complete()
+static void mem_source_machine_ready(Notifier *notifier, void *data)
+{
+    Chardev *chr;
+    MemSourceState *ms = container_of(notifier, MemSourceState, machine_ready);
+    Error *local_err = NULL;
+
+    info_report("%s: source %p", __func__, ms);
+
+    chr = qemu_chr_find(ms->chardev);
+    if (!chr) {
+        error_setg(&local_err, "Chardev '%s' not found", ms->chardev);
+        goto out;
+    }
+
+    if (!qemu_chr_fe_init(&ms->chr, chr, &local_err)) {
+        // errp already filled by qemu_chr_fe_init()
+        goto out;
+    }
+
+    if (qemu_chr_fe_reconnect_time(&ms->chr, 0) != 0) {
+        error_setg(&local_err, "Chardev '%s' has reconnect time, reset and disconnected", ms->chardev);
+        qemu_chr_fe_disconnect(&ms->chr);
+    }
+
+    qemu_chr_fe_set_handlers(&ms->chr, mem_chardev_can_read, mem_chardev_read,
+                             mem_chardev_event, NULL, ms, NULL, true);
+
+out:
+    if (local_err) {
+        warn_report_err(local_err);
+        qemu_chr_fe_deinit(&ms->chr, true);
+    }
+}
+
+/*
+ * Open file descriptors needed for introspection. These shouldn't be closed.
+ * With the current guest-introspector handshake, the SVA may close and lose
+ * introspector-related info, so the fds need to be re-sent to the SVA.
+ */
+static void mem_source_init_introspection(MemSourceState *ms, Error **errp)
+{
+    int result;
+
+    ms->pidfd = syscall(__NR_pidfd_open, getpid(), 0);
+    if (ms->pidfd < 0) {
+        error_setg_errno(errp, errno, "Failed getting pidfd of current process");
+        return;
+    }
+
+    result = syscall(__NR_pidfd_mem, ms->pidfd, &ms->fds, 0);
+    if (result) {
+        error_setg_errno(errp, errno, "Failed creating pidfd_mem fds");
+        return;
+    }
+
+    info_report("%s: introspection seems to work...", __func__);
+}
+
+// user creatable
+static void mem_source_complete(UserCreatable *uc, Error **errp)
+{
+    MemSourceState *ms = MEM_SOURCE(uc);
+
+    info_report("%s: source %p", __func__, ms);
+
+    if (!ms->chardev) {
+        error_setg(errp, "Memory introspection needs a (unix socket) chardev ID");
+        return;
+    }
+
+    /* all else is worthless without these fds */
+    mem_source_init_introspection(ms, errp);
+    if (*errp) {
+        /* errp was filled by mem_source_init_introspection() */
+
+        // TODO: remove me when we merge remote mapping v2
+        warn_report_err(*errp);
+        *errp = NULL;
+
+        return;
+    }
+
+    /* start the mem listener independent of the socket connection */
+    memory_listener_register(&ms->mlisten, &address_space_memory);
+
+    /* chardevs are not available this early */
+    qemu_add_machine_init_done_notifier(&ms->machine_ready);
+}
+
+// user creatable
+static bool mem_source_can_be_deleted(UserCreatable *uc)
+{
+    MemSourceState *ms = MEM_SOURCE(uc);
+
+    info_report("%s: source %p", __func__, ms);
+
+    // right now we have no restrictions
+    return true;
+}
+
+// property
+static char *mem_source_get_chardev(Object *obj, Error **errp)
+{
+    MemSourceState *ms = MEM_SOURCE(obj);
+
+    return g_strdup(ms->chardev);
+}
+
+// property
+static void mem_source_set_chardev(Object *obj, const char *str, Error **errp)
+{
+    MemSourceState *ms = MEM_SOURCE(obj);
+
+    g_free(ms->chardev);
+    ms->chardev = g_strdup(str);
+}
+
+static void mem_source_class_init(ObjectClass *oc, void *data)
+{
+    UserCreatableClass *uc = USER_CREATABLE_CLASS(oc);
+
+    object_class_property_add_str(oc, "chardev",
+        mem_source_get_chardev,
+        mem_source_set_chardev,
+        &error_abort);
+    object_class_property_set_description(oc, "chardev",
+        "A backend used to communicate memory metadata",
+        &error_abort);
+
+    uc->complete = mem_source_complete;
+    uc->can_be_deleted = mem_source_can_be_deleted;
+}
+
+static const TypeInfo mem_source_info = {
+    .name = TYPE_MEM_SOURCE,
+    .parent = TYPE_OBJECT,
+
+    .instance_size = sizeof(MemSourceState),
+    .instance_init = mem_source_instance_init,
+    .instance_finalize = mem_source_instance_finalize,
+
+    .class_init = mem_source_class_init,
+    .interfaces = (InterfaceInfo[]) {
+        {TYPE_USER_CREATABLE},
+        {}
+    }
+};
+
+static void mem_source_register_types(void)
+{
+    type_register_static(&mem_source_info);
+}
+
+type_init(mem_source_register_types)

--- a/accel/kvm/vmi.c
+++ b/accel/kvm/vmi.c
@@ -71,6 +71,9 @@ typedef struct VMIntrospection {
     QDict *qmp_rsp;
 
     bool kvmi_hooked;
+
+    GArray *allowed_commands;
+    GArray *allowed_events;
 } VMIntrospection;
 
 typedef struct VMIntrospectionClass {
@@ -86,6 +89,8 @@ static const char *action_string[] = {
 };
 
 static bool suspend_pending;
+
+static __s32 all_IDs = -1;
 
 #define TYPE_VM_INTROSPECTION "introspection"
 
@@ -279,6 +284,25 @@ static void prop_set_uint32(Object *obj, Visitor *v, const char *name,
     }
 }
 
+static void prop_add_to_array(Object *obj, Visitor *v,
+                              const char *name, void *opaque,
+                              Error **errp)
+{
+    Error *local_err = NULL;
+    GArray *arr = opaque;
+    uint32_t value;
+
+    visit_type_uint32(v, name, &value, &local_err);
+    if (!local_err && value == (uint32_t)all_IDs) {
+        error_setg(&local_err, "VMI: add %s: invalid id %d", name, value);
+    }
+    if (local_err) {
+        error_propagate(errp, local_err);
+    } else {
+        g_array_append_val(arr, value);
+    }
+}
+
 static bool vmi_can_be_deleted(UserCreatable *uc)
 {
     VMIntrospection *i = VM_INTROSPECTION(uc);
@@ -305,6 +329,15 @@ static void instance_init(Object *obj)
 
     object_property_add_str(obj, "chardev", NULL, prop_set_chardev, NULL);
     object_property_add_str(obj, "key", NULL, prop_set_key, NULL);
+
+    i->allowed_commands = g_array_new(FALSE, FALSE, sizeof(uint32_t));
+    object_property_add(obj, "command", "uint32",
+                        prop_add_to_array, NULL,
+                        NULL, i->allowed_commands, NULL);
+    i->allowed_events = g_array_new(FALSE, FALSE, sizeof(uint32_t));
+    object_property_add(obj, "event", "uint32",
+                        prop_add_to_array, NULL,
+                        NULL, i->allowed_events, NULL);
 
     i->handshake_timeout = HANDSHAKE_TIMEOUT_SEC;
     object_property_add(obj, "handshake_timeout", "uint32",
@@ -370,6 +403,13 @@ static void instance_finalize(Object *obj)
 {
     VMIntrospectionClass *ic = VM_INTROSPECTION_CLASS(obj->class);
     VMIntrospection *i = VM_INTROSPECTION(obj);
+
+    if (i->allowed_commands) {
+        g_array_free(i->allowed_commands, TRUE);
+    }
+    if (i->allowed_events) {
+        g_array_free(i->allowed_events, TRUE);
+    }
 
     g_free(i->chardevid);
     g_free(i->keyid);
@@ -481,11 +521,39 @@ static bool validate_handshake(VMIntrospection *i, Error **errp)
     return true;
 }
 
+static bool set_allowed_features(int ioctl, GArray *allowed, Error **errp)
+{
+    struct kvm_introspection_feature feature;
+    gint i;
+
+    feature.allow = 1;
+
+    if (allowed->len == 0) {
+        feature.id = all_IDs;
+        if (kvm_vm_ioctl(kvm_state, ioctl, &feature)) {
+            goto out_err;
+        }
+    } else {
+        for (i = 0; i < allowed->len; i++) {
+            feature.id = g_array_index(allowed, uint32_t, i);
+            if (kvm_vm_ioctl(kvm_state, ioctl, &feature)) {
+                goto out_err;
+            }
+        }
+    }
+
+    return true;
+
+out_err:
+    error_setg_errno(errp, errno,
+                     "VMI: feature %d with id %d failed",
+                     ioctl, feature.id);
+    return false;
+}
+
 static bool connect_kernel(VMIntrospection *i, Error **errp)
 {
-    struct kvm_introspection_feature commands, events;
     struct kvm_introspection_hook kernel;
-    const __s32 all_ids = -1;
 
     memset(&kernel, 0, sizeof(kernel));
     memcpy(kernel.uuid, &qemu_uuid, sizeof(kernel.uuid));
@@ -502,19 +570,13 @@ static bool connect_kernel(VMIntrospection *i, Error **errp)
         return false;
     }
 
-    commands.allow = 1;
-    commands.id = all_ids;
-    if (kvm_vm_ioctl(kvm_state, KVM_INTROSPECTION_COMMAND, &commands)) {
-        error_setg_errno(errp, errno,
-                         "VMI: ioctl/KVM_INTROSPECTION_COMMAND failed");
+    if (!set_allowed_features(KVM_INTROSPECTION_COMMAND,
+                              i->allowed_commands, errp)) {
         goto error;
     }
 
-    events.allow = 1;
-    events.id = all_ids;
-    if (kvm_vm_ioctl(kvm_state, KVM_INTROSPECTION_EVENT, &events)) {
-        error_setg_errno(errp, errno,
-                         "VMI: ioctl/KVM_INTROSPECTION_EVENT failed");
+    if (!set_allowed_features(KVM_INTROSPECTION_EVENT,
+                              i->allowed_events, errp)) {
         goto error;
     }
 

--- a/accel/kvm/vmi.c
+++ b/accel/kvm/vmi.c
@@ -20,6 +20,7 @@
 #include "crypto/hash.h"
 #include "chardev/char.h"
 #include "chardev/char-fe.h"
+#include "migration/vmstate.h"
 
 #include "sysemu/vmi-intercept.h"
 #include "sysemu/vmi-handshake.h"
@@ -119,6 +120,16 @@ static void vmi_reset(void *opaque)
     update_vm_start_time(i);
 }
 
+static const VMStateDescription vmstate_introspection = {
+    .name = "vm_introspection",
+    .minimum_version_id = 1,
+    .version_id = 1,
+    .fields = (VMStateField[]) {
+        VMSTATE_INT64(vm_start_time, VMIntrospection),
+        VMSTATE_END_OF_LIST()
+    }
+};
+
 static void vmi_complete(UserCreatable *uc, Error **errp)
 {
     VMIntrospectionClass *ic = VM_INTROSPECTION_CLASS(OBJECT(uc)->class);
@@ -156,6 +167,8 @@ static void vmi_complete(UserCreatable *uc, Error **errp)
     ic->uniq = i;
 
     update_vm_start_time(i);
+
+    vmstate_register(NULL, 0, &vmstate_introspection, i);
 
     qemu_register_reset(vmi_reset, i);
 }

--- a/accel/kvm/vmi.c
+++ b/accel/kvm/vmi.c
@@ -14,6 +14,8 @@
 #include "qom/object_interfaces.h"
 #include "sysemu/sysemu.h"
 #include "sysemu/kvm.h"
+#include "crypto/secret.h"
+#include "crypto/hash.h"
 #include "chardev/char.h"
 #include "chardev/char-fe.h"
 
@@ -30,6 +32,11 @@ typedef struct VMIntrospection {
     Chardev *chr;
     CharBackend sock;
     bool connected;
+
+    char *keyid;
+    Object *key;
+    uint8_t cookie_hash[QEMU_VMI_COOKIE_HASH_SIZE];
+    bool key_with_cookie;
 
     qemu_vmi_from_introspector hsk_in;
     uint64_t hsk_in_read_pos;
@@ -111,6 +118,14 @@ static void prop_set_chardev(Object *obj, const char *value, Error **errp)
     i->chardevid = g_strdup(value);
 }
 
+static void prop_set_key(Object *obj, const char *value, Error **errp)
+{
+    VMIntrospection *i = VM_INTROSPECTION(obj);
+
+    g_free(i->keyid);
+    i->keyid = g_strdup(value);
+}
+
 static void prop_get_uint32(Object *obj, Visitor *v, const char *name,
                             void *opaque, Error **errp)
 {
@@ -145,6 +160,7 @@ static void instance_init(Object *obj)
     i->created_from_command_line = (qdev_hotplug == false);
 
     object_property_add_str(obj, "chardev", NULL, prop_set_chardev, NULL);
+    object_property_add_str(obj, "key", NULL, prop_set_key, NULL);
 
     i->handshake_timeout = HANDSHAKE_TIMEOUT_SEC;
     object_property_add(obj, "handshake_timeout", "uint32",
@@ -195,6 +211,7 @@ static void instance_finalize(Object *obj)
     VMIntrospection *i = VM_INTROSPECTION(obj);
 
     g_free(i->chardevid);
+    g_free(i->keyid);
 
     cancel_handshake_timer(i);
 
@@ -256,6 +273,16 @@ static bool send_handshake_info(VMIntrospection *i, Error **errp)
     return true;
 }
 
+static bool validate_handshake_cookie(VMIntrospection *i)
+{
+    if (!i->key_with_cookie) {
+        return true;
+    }
+
+    return 0 == memcmp(&i->cookie_hash, &i->hsk_in.cookie_hash,
+                       sizeof(i->cookie_hash));
+}
+
 static bool validate_handshake(VMIntrospection *i, Error **errp)
 {
     uint32_t min_accepted_size;
@@ -265,6 +292,11 @@ static bool validate_handshake(VMIntrospection *i, Error **errp)
 
     if (i->hsk_in.struct_size < min_accepted_size) {
         error_setg(errp, "VMI: not enough or invalid handshake data");
+        return false;
+    }
+
+    if (!validate_handshake_cookie(i)) {
+        error_setg(errp, "VMI: received cookie doesn't match");
         return false;
     }
 
@@ -473,6 +505,31 @@ static void vmi_chr_event(void *opaque, int event)
     }
 }
 
+static bool make_cookie_hash(const char *key_id, uint8_t *cookie_hash,
+                             Error **errp)
+{
+    uint8_t *cookie = NULL, *hash = NULL;
+    size_t cookie_size, hash_size = 0;
+    bool done = false;
+
+    if (qcrypto_secret_lookup(key_id, &cookie, &cookie_size, errp) == 0
+            && qcrypto_hash_bytes(QCRYPTO_HASH_ALG_SHA1,
+                                  (const char *)cookie, cookie_size,
+                                  &hash, &hash_size, errp) == 0) {
+        if (hash_size == QEMU_VMI_COOKIE_HASH_SIZE) {
+            memcpy(cookie_hash, hash, QEMU_VMI_COOKIE_HASH_SIZE);
+            done = true;
+        } else {
+            error_setg(errp, "VMI: hash algorithm size mismatch");
+        }
+    }
+
+    g_free(cookie);
+    g_free(hash);
+
+    return done;
+}
+
 static Error *vm_introspection_init(VMIntrospection *i)
 {
     Error *err = NULL;
@@ -489,6 +546,15 @@ static Error *vm_introspection_init(VMIntrospection *i)
         error_setg(&err,
                    "VMI: missing kernel built with CONFIG_KVM_INTROSPECTION");
         return err;
+    }
+
+    if (i->keyid) {
+        if (!make_cookie_hash(i->keyid, i->cookie_hash, &err)) {
+            return err;
+        }
+        i->key_with_cookie = true;
+    } else {
+        warn_report("VMI: the introspection tool won't be 'authenticated'");
     }
 
     chr = qemu_chr_find(i->chardevid);

--- a/accel/kvm/vmi.c
+++ b/accel/kvm/vmi.c
@@ -1,0 +1,162 @@
+/*
+ * VM Introspection
+ *
+ * Copyright (C) 2017-2020 Bitdefender S.R.L.
+ *
+ * This work is licensed under the terms of the GNU GPL, version 2 or later.
+ * See the COPYING file in the top-level directory.
+ */
+
+#include "qemu/osdep.h"
+#include "qapi/error.h"
+#include "qemu/error-report.h"
+#include "qom/object_interfaces.h"
+#include "sysemu/sysemu.h"
+#include "sysemu/kvm.h"
+#include "chardev/char.h"
+#include "chardev/char-fe.h"
+
+typedef struct VMIntrospection {
+    Object parent_obj;
+
+    Error *init_error;
+
+    char *chardevid;
+    Chardev *chr;
+
+    Notifier machine_ready;
+    bool created_from_command_line;
+} VMIntrospection;
+
+#define TYPE_VM_INTROSPECTION "introspection"
+
+#define VM_INTROSPECTION(obj) \
+    OBJECT_CHECK(VMIntrospection, (obj), TYPE_VM_INTROSPECTION)
+
+static Error *vm_introspection_init(VMIntrospection *i);
+
+static void vmi_machine_ready(Notifier *notifier, void *data)
+{
+    VMIntrospection *i = container_of(notifier, VMIntrospection, machine_ready);
+
+    i->init_error = vm_introspection_init(i);
+    if (i->init_error) {
+        Error *err = error_copy(i->init_error);
+
+        error_report_err(err);
+        if (i->created_from_command_line) {
+            exit(1);
+        }
+    }
+}
+
+static void vmi_complete(UserCreatable *uc, Error **errp)
+{
+    VMIntrospection *i = VM_INTROSPECTION(uc);
+
+    if (!i->chardevid) {
+        error_setg(errp, "VMI: chardev is not set");
+        return;
+    }
+
+    i->machine_ready.notify = vmi_machine_ready;
+    qemu_add_machine_init_done_notifier(&i->machine_ready);
+
+    /*
+     * If the introspection object is created while parsing the command line,
+     * the machine_ready callback will be called later. At that time,
+     * it vm_introspection_init() fails, exit() will be called.
+     *
+     * If the introspection object is created through QMP, machine_init_done
+     * is already set and qemu_add_machine_init_done_notifier() will
+     * call our machine_done() callback. If vm_introspection_init() fails,
+     * we don't call exit() and report the error back to the user.
+     */
+    if (i->init_error) {
+        *errp = i->init_error;
+        i->init_error = NULL;
+        return;
+    }
+}
+
+static void prop_set_chardev(Object *obj, const char *value, Error **errp)
+{
+    VMIntrospection *i = VM_INTROSPECTION(obj);
+
+    g_free(i->chardevid);
+    i->chardevid = g_strdup(value);
+}
+
+static void class_init(ObjectClass *oc, void *data)
+{
+    UserCreatableClass *uc = USER_CREATABLE_CLASS(oc);
+
+    uc->complete = vmi_complete;
+}
+
+static void instance_init(Object *obj)
+{
+    VMIntrospection *i = VM_INTROSPECTION(obj);
+
+    i->created_from_command_line = (qdev_hotplug == false);
+
+    object_property_add_str(obj, "chardev", NULL, prop_set_chardev, NULL);
+}
+
+static void instance_finalize(Object *obj)
+{
+    VMIntrospection *i = VM_INTROSPECTION(obj);
+
+    g_free(i->chardevid);
+
+    error_free(i->init_error);
+}
+
+static const TypeInfo info = {
+    .name              = TYPE_VM_INTROSPECTION,
+    .parent            = TYPE_OBJECT,
+    .class_init        = class_init,
+    .instance_size     = sizeof(VMIntrospection),
+    .instance_finalize = instance_finalize,
+    .instance_init     = instance_init,
+    .interfaces        = (InterfaceInfo[]){
+        {TYPE_USER_CREATABLE},
+        {}
+    }
+};
+
+static void register_types(void)
+{
+    type_register_static(&info);
+}
+
+type_init(register_types);
+
+static Error *vm_introspection_init(VMIntrospection *i)
+{
+    Error *err = NULL;
+    int kvmi_version;
+    Chardev *chr;
+
+    if (!kvm_enabled()) {
+        error_setg(&err, "VMI: missing KVM support");
+        return err;
+    }
+
+    kvmi_version = kvm_check_extension(kvm_state, KVM_CAP_INTROSPECTION);
+    if (kvmi_version == 0) {
+        error_setg(&err,
+                   "VMI: missing kernel built with CONFIG_KVM_INTROSPECTION");
+        return err;
+    }
+
+    chr = qemu_chr_find(i->chardevid);
+    if (!chr) {
+        error_setg(&err, "VMI: device '%s' not found", i->chardevid);
+        return err;
+    }
+
+    i->chr = chr;
+
+    return NULL;
+}

--- a/accel/kvm/vmi.c
+++ b/accel/kvm/vmi.c
@@ -56,6 +56,7 @@ typedef struct VMIntrospection {
     int intercepted_action;
     GSource *unhook_timer;
     uint32_t unhook_timeout;
+    bool async_unhook;
 
     int reconnect_time;
 
@@ -233,6 +234,20 @@ static void prop_set_key(Object *obj, const char *value, Error **errp)
     i->keyid = g_strdup(value);
 }
 
+static bool prop_get_async_unhook(Object *obj, Error **errp)
+{
+    VMIntrospection *i = VM_INTROSPECTION(obj);
+
+    return i->async_unhook;
+}
+
+static void prop_set_async_unhook(Object *obj, bool value, Error **errp)
+{
+    VMIntrospection *i = VM_INTROSPECTION(obj);
+
+    i->async_unhook = value;
+}
+
 static void prop_get_uint32(Object *obj, Visitor *v, const char *name,
                             void *opaque, Error **errp)
 {
@@ -289,6 +304,11 @@ static void instance_init(Object *obj)
     object_property_add(obj, "unhook_timeout", "uint32",
                         prop_set_uint32, prop_get_uint32,
                         NULL, &i->unhook_timeout, NULL);
+
+    i->async_unhook = true;
+    object_property_add_bool(obj, "async_unhook",
+                             prop_get_async_unhook,
+                             prop_set_async_unhook, NULL);
 }
 
 static void disconnect_chardev(VMIntrospection *i)
@@ -771,6 +791,19 @@ static bool record_intercept_action(VMI_intercept_command action)
     return true;
 }
 
+static void wait_until_the_socket_is_closed(VMIntrospection *i)
+{
+    info_report("VMI: start waiting until socket is closed");
+
+    while (i->connected) {
+        main_loop_wait(false);
+    }
+
+    info_report("VMI: continue with the intercepted action");
+
+    maybe_disable_socket_reconnect(i);
+}
+
 static bool vmi_maybe_wait_for_unhook(VMIntrospection *i,
                                       VMI_intercept_command action)
 {
@@ -782,6 +815,11 @@ static bool vmi_maybe_wait_for_unhook(VMIntrospection *i,
     i->unhook_timer = qemu_chr_timeout_add_ms(i->chr,
                                               i->unhook_timeout * 1000,
                                               unhook_timeout_cbk, i);
+
+    if (!i->async_unhook) {
+        wait_until_the_socket_is_closed(i);
+        return false;
+    }
 
     i->intercepted_action = action;
     return true;

--- a/accel/kvm/vmi.c
+++ b/accel/kvm/vmi.c
@@ -8,6 +8,7 @@
  */
 
 #include "qemu/osdep.h"
+#include "qemu-common.h"
 #include "qapi/error.h"
 #include "qemu/error-report.h"
 #include "qom/object_interfaces.h"
@@ -16,6 +17,8 @@
 #include "chardev/char.h"
 #include "chardev/char-fe.h"
 
+#include "sysemu/vmi-handshake.h"
+
 typedef struct VMIntrospection {
     Object parent_obj;
 
@@ -23,9 +26,19 @@ typedef struct VMIntrospection {
 
     char *chardevid;
     Chardev *chr;
+    CharBackend sock;
+    bool connected;
+
+    qemu_vmi_from_introspector hsk_in;
+    uint64_t hsk_in_read_pos;
+    uint64_t hsk_in_read_size;
+
+    int64_t vm_start_time;
 
     Notifier machine_ready;
     bool created_from_command_line;
+
+    bool kvmi_hooked;
 } VMIntrospection;
 
 #define TYPE_VM_INTROSPECTION "introspection"
@@ -48,6 +61,11 @@ static void vmi_machine_ready(Notifier *notifier, void *data)
             exit(1);
         }
     }
+}
+
+static void update_vm_start_time(VMIntrospection *i)
+{
+    i->vm_start_time = qemu_clock_get_ms(QEMU_CLOCK_REALTIME) / 1000;
 }
 
 static void vmi_complete(UserCreatable *uc, Error **errp)
@@ -77,6 +95,8 @@ static void vmi_complete(UserCreatable *uc, Error **errp)
         i->init_error = NULL;
         return;
     }
+
+    update_vm_start_time(i);
 }
 
 static void prop_set_chardev(Object *obj, const char *value, Error **errp)
@@ -103,11 +123,39 @@ static void instance_init(Object *obj)
     object_property_add_str(obj, "chardev", NULL, prop_set_chardev, NULL);
 }
 
+static void disconnect_chardev(VMIntrospection *i)
+{
+    if (i->connected) {
+        qemu_chr_fe_disconnect(&i->sock);
+    }
+}
+
+static void unhook_kvmi(VMIntrospection *i)
+{
+    if (i->kvmi_hooked) {
+        if (kvm_vm_ioctl(kvm_state, KVM_INTROSPECTION_UNHOOK, NULL)) {
+            error_report("VMI: ioctl/KVM_INTROSPECTION_UNHOOK failed, errno %d",
+                         errno);
+        }
+        i->kvmi_hooked = false;
+    }
+}
+
+static void disconnect_and_unhook_kvmi(VMIntrospection *i)
+{
+    disconnect_chardev(i);
+    unhook_kvmi(i);
+}
+
 static void instance_finalize(Object *obj)
 {
     VMIntrospection *i = VM_INTROSPECTION(obj);
 
     g_free(i->chardevid);
+
+    if (i->chr) {
+        qemu_chr_fe_deinit(&i->sock, true);
+    }
 
     error_free(i->init_error);
 }
@@ -131,6 +179,234 @@ static void register_types(void)
 }
 
 type_init(register_types);
+
+static bool send_handshake_info(VMIntrospection *i, Error **errp)
+{
+    qemu_vmi_to_introspector send = {};
+    const char *vm_name;
+    int r;
+
+    send.struct_size = sizeof(send);
+    send.start_time = i->vm_start_time;
+    memcpy(&send.uuid, &qemu_uuid, sizeof(send.uuid));
+    vm_name = qemu_get_vm_name();
+    if (vm_name) {
+        snprintf(send.name, sizeof(send.name), "%s", vm_name);
+        send.name[sizeof(send.name) - 1] = 0;
+    }
+
+    r = qemu_chr_fe_write_all(&i->sock, (uint8_t *)&send, sizeof(send));
+    if (r != sizeof(send)) {
+        error_setg_errno(errp, errno, "VMI: error writing to '%s'",
+                         i->chardevid);
+        return false;
+    }
+
+    /* tcp_chr_write may call tcp_chr_disconnect/CHR_EVENT_CLOSED */
+    if (!i->connected) {
+        error_setg(errp, "VMI: qemu_chr_fe_write_all() failed");
+        return false;
+    }
+
+    return true;
+}
+
+static bool validate_handshake(VMIntrospection *i, Error **errp)
+{
+    uint32_t min_accepted_size;
+
+    min_accepted_size = offsetof(qemu_vmi_from_introspector, cookie_hash)
+                        + QEMU_VMI_COOKIE_HASH_SIZE;
+
+    if (i->hsk_in.struct_size < min_accepted_size) {
+        error_setg(errp, "VMI: not enough or invalid handshake data");
+        return false;
+    }
+
+    /*
+     * Check hsk_in.struct_size and sizeof(hsk_in) before accessing any
+     * other fields. We might get fewer bytes from applications using
+     * old versions if we extended the qemu_vmi_from_introspector structure.
+     */
+
+    return true;
+}
+
+static bool connect_kernel(VMIntrospection *i, Error **errp)
+{
+    struct kvm_introspection_feature commands, events;
+    struct kvm_introspection_hook kernel;
+    const __s32 all_ids = -1;
+
+    memset(&kernel, 0, sizeof(kernel));
+    memcpy(kernel.uuid, &qemu_uuid, sizeof(kernel.uuid));
+    kernel.fd = object_property_get_int(OBJECT(i->chr), "fd", NULL);
+
+    if (kvm_vm_ioctl(kvm_state, KVM_INTROSPECTION_HOOK, &kernel)) {
+        error_setg_errno(errp, errno,
+                         "VMI: ioctl/KVM_INTROSPECTION_HOOK failed");
+        if (errno == EPERM) {
+            error_append_hint(errp,
+                              "Reload the kvm module with kvm.introspection=on\n");
+        }
+
+        return false;
+    }
+
+    commands.allow = 1;
+    commands.id = all_ids;
+    if (kvm_vm_ioctl(kvm_state, KVM_INTROSPECTION_COMMAND, &commands)) {
+        error_setg_errno(errp, errno,
+                         "VMI: ioctl/KVM_INTROSPECTION_COMMAND failed");
+        goto error;
+    }
+
+    events.allow = 1;
+    events.id = all_ids;
+    if (kvm_vm_ioctl(kvm_state, KVM_INTROSPECTION_EVENT, &events)) {
+        error_setg_errno(errp, errno,
+                         "VMI: ioctl/KVM_INTROSPECTION_EVENT failed");
+        goto error;
+    }
+
+    info_report("VMI: machine hooked");
+    i->kvmi_hooked = true;
+
+    return true;
+
+error:
+    if (kvm_vm_ioctl(kvm_state, KVM_INTROSPECTION_UNHOOK, NULL)) {
+        error_setg_errno(errp, errno,
+                         "VMI: ioctl/KVM_INTROSPECTION_UNHOOK failed");
+    }
+
+    return false;
+}
+
+/*
+ * We should read only the handshake structure,
+ * which might have a different size than what we expect.
+ */
+static int vmi_chr_can_read(void *opaque)
+{
+    VMIntrospection *i = opaque;
+
+    if (!i->connected) {
+        return 0;
+    }
+
+    /* first, we read the incoming structure size */
+    if (i->hsk_in_read_pos == 0) {
+        return sizeof(i->hsk_in.struct_size);
+    }
+
+    /* validate the incoming structure size */
+    if (i->hsk_in.struct_size < sizeof(i->hsk_in.struct_size)) {
+        return 0;
+    }
+
+    /* read the rest of the incoming structure */
+    return i->hsk_in.struct_size - i->hsk_in_read_pos;
+}
+
+static bool enough_bytes_for_handshake(VMIntrospection *i)
+{
+    return i->hsk_in_read_pos  >= sizeof(i->hsk_in.struct_size)
+        && i->hsk_in_read_size == i->hsk_in.struct_size;
+}
+
+static bool validate_and_connect(VMIntrospection *i, Error **errp)
+{
+    if (!validate_handshake(i, errp)) {
+        return false;
+    }
+
+    if (!connect_kernel(i, errp)) {
+        return false;
+    }
+
+    return true;
+}
+
+static void vmi_chr_read(void *opaque, const uint8_t *buf, int size)
+{
+    VMIntrospection *i = opaque;
+    size_t to_read;
+
+    i->hsk_in_read_size += size;
+
+    to_read = sizeof(i->hsk_in) - i->hsk_in_read_pos;
+    if (to_read > size) {
+        to_read = size;
+    }
+
+    if (to_read) {
+        memcpy((uint8_t *)&i->hsk_in + i->hsk_in_read_pos, buf, to_read);
+        i->hsk_in_read_pos += to_read;
+    }
+
+    if (enough_bytes_for_handshake(i)) {
+        Error *local_err = NULL;
+
+        if (!validate_and_connect(i, &local_err)) {
+            error_append_hint(&local_err, "reconnecting\n");
+            warn_report_err(local_err);
+            qemu_chr_fe_disconnect(&i->sock);
+        }
+    }
+}
+
+static void vmi_start_handshake(void *opaque)
+{
+    VMIntrospection *i = opaque;
+    Error *local_err = NULL;
+
+    if (!send_handshake_info(i, &local_err)) {
+        error_append_hint(&local_err, "reconnecting\n");
+        warn_report_err(local_err);
+        qemu_chr_fe_disconnect(&i->sock);
+        return;
+    }
+
+    info_report("VMI: handshake started");
+}
+
+static void vmi_chr_event_open(VMIntrospection *i)
+{
+    i->connected = true;
+
+    memset(&i->hsk_in, 0, sizeof(i->hsk_in));
+    i->hsk_in_read_pos = 0;
+    i->hsk_in_read_size = 0;
+
+    vmi_start_handshake(i);
+}
+
+static void vmi_chr_event_closed(VMIntrospection *i)
+{
+    i->connected = false;
+
+    if (i->kvmi_hooked) {
+        warn_report("VMI: introspection tool disconnected");
+        disconnect_and_unhook_kvmi(i);
+    }
+}
+
+static void vmi_chr_event(void *opaque, int event)
+{
+    VMIntrospection *i = opaque;
+
+    switch (event) {
+    case CHR_EVENT_OPENED:
+        vmi_chr_event_open(i);
+        break;
+    case CHR_EVENT_CLOSED:
+        vmi_chr_event_closed(i);
+        break;
+    default:
+        break;
+    }
+}
 
 static Error *vm_introspection_init(VMIntrospection *i)
 {
@@ -156,7 +432,31 @@ static Error *vm_introspection_init(VMIntrospection *i)
         return err;
     }
 
+    if (!qemu_chr_fe_init(&i->sock, chr, &err)) {
+        error_append_hint(&err, "VMI: device '%s' not initialized\n",
+                          i->chardevid);
+        return err;
+    }
+
     i->chr = chr;
+
+    if (qemu_chr_fe_reconnect_time(&i->sock, -1) <= 0) {
+        error_setg(&err, "VMI: missing reconnect=N for '%s'",
+                          i->chardevid);
+        return err;
+    }
+
+    qemu_chr_fe_set_handlers(&i->sock, vmi_chr_can_read, vmi_chr_read,
+                             vmi_chr_event, NULL, i, NULL, true);
+
+    /*
+     * The reconnect timer is triggered by either machine init or by a chardev
+     * disconnect. For the QMP creation, when the machine is already started,
+     * use an artificial disconnect just to restart the timer.
+     */
+    if (!i->created_from_command_line) {
+        qemu_chr_fe_disconnect(&i->sock);
+    }
 
     return NULL;
 }

--- a/accel/kvm/vmi.c
+++ b/accel/kvm/vmi.c
@@ -14,12 +14,14 @@
 #include "qom/object_interfaces.h"
 #include "sysemu/sysemu.h"
 #include "sysemu/reset.h"
+#include "sysemu/runstate.h"
 #include "sysemu/kvm.h"
 #include "crypto/secret.h"
 #include "crypto/hash.h"
 #include "chardev/char.h"
 #include "chardev/char-fe.h"
 
+#include "sysemu/vmi-intercept.h"
 #include "sysemu/vmi-handshake.h"
 
 #define HANDSHAKE_TIMEOUT_SEC 10
@@ -45,6 +47,10 @@ typedef struct VMIntrospection {
     GSource *hsk_timer;
     uint32_t handshake_timeout;
 
+    int intercepted_action;
+
+    int reconnect_time;
+
     int64_t vm_start_time;
 
     Notifier machine_ready;
@@ -58,6 +64,14 @@ typedef struct VMIntrospectionClass {
     uint32_t instance_counter;
     VMIntrospection *uniq;
 } VMIntrospectionClass;
+
+static const char *action_string[] = {
+    "none",
+    "suspend",
+    "resume",
+};
+
+static bool suspend_pending;
 
 #define TYPE_VM_INTROSPECTION "introspection"
 
@@ -413,6 +427,40 @@ error:
     return false;
 }
 
+static void enable_socket_reconnect(VMIntrospection *i)
+{
+    if (i->reconnect_time) {
+        info_report("VMI: re-enable socket reconnect");
+        qemu_chr_fe_reconnect_time(&i->sock, i->reconnect_time);
+        qemu_chr_fe_disconnect(&i->sock);
+        i->reconnect_time = 0;
+    }
+}
+
+static void maybe_disable_socket_reconnect(VMIntrospection *i)
+{
+    if (i->reconnect_time == 0) {
+        info_report("VMI: disable socket reconnect");
+        i->reconnect_time = qemu_chr_fe_reconnect_time(&i->sock, 0);
+    }
+}
+
+static void continue_with_the_intercepted_action(VMIntrospection *i)
+{
+    switch (i->intercepted_action) {
+    case VMI_INTERCEPT_SUSPEND:
+        vm_stop(RUN_STATE_PAUSED);
+        break;
+    default:
+        error_report("VMI: %s: unexpected action %d",
+                     __func__, i->intercepted_action);
+        break;
+    }
+
+    info_report("VMI: continue with '%s'",
+                action_string[i->intercepted_action]);
+}
+
 /*
  * We should read only the handshake structure,
  * which might have a different size than what we expect.
@@ -519,6 +567,14 @@ static void vmi_chr_event_open(VMIntrospection *i)
 {
     i->connected = true;
 
+    if (suspend_pending) {
+        info_report("VMI: %s: too soon (suspend=%d)",
+                    __func__, suspend_pending);
+        maybe_disable_socket_reconnect(i);
+        qemu_chr_fe_disconnect(&i->sock);
+        return;
+    }
+
     memset(&i->hsk_in, 0, sizeof(i->hsk_in));
     i->hsk_in_read_pos = 0;
     i->hsk_in_read_size = 0;
@@ -540,6 +596,15 @@ static void vmi_chr_event_closed(VMIntrospection *i)
     }
 
     cancel_handshake_timer(i);
+
+    if (suspend_pending) {
+        maybe_disable_socket_reconnect(i);
+
+        if (i->intercepted_action != VMI_INTERCEPT_NONE) {
+            continue_with_the_intercepted_action(i);
+            i->intercepted_action = VMI_INTERCEPT_NONE;
+        }
+    }
 }
 
 static void vmi_chr_event(void *opaque, int event)
@@ -556,6 +621,92 @@ static void vmi_chr_event(void *opaque, int event)
     default:
         break;
     }
+}
+
+static VMIntrospection *vm_introspection_object(void)
+{
+    VMIntrospectionClass *ic;
+
+    ic = VM_INTROSPECTION_CLASS(object_class_by_name(TYPE_VM_INTROSPECTION));
+
+    return ic ? ic->uniq : NULL;
+}
+
+/*
+ * This ioctl succeeds only when KVM signals the introspection tool.
+ * (the socket is connected and the event was sent without error).
+ */
+static bool signal_introspection_tool_to_unhook(VMIntrospection *i)
+{
+    int err;
+
+    err = kvm_vm_ioctl(kvm_state, KVM_INTROSPECTION_PREUNHOOK, NULL);
+
+    return !err;
+}
+
+static bool record_intercept_action(VMI_intercept_command action)
+{
+    switch (action) {
+    case VMI_INTERCEPT_SUSPEND:
+        suspend_pending = true;
+        break;
+    case VMI_INTERCEPT_RESUME:
+        suspend_pending = false;
+        break;
+    default:
+        return false;
+    }
+
+    return true;
+}
+
+static bool vmi_maybe_wait_for_unhook(VMIntrospection *i,
+                                      VMI_intercept_command action)
+{
+    if (!signal_introspection_tool_to_unhook(i)) {
+        disconnect_and_unhook_kvmi(i);
+        return false;
+    }
+
+    i->intercepted_action = action;
+    return true;
+}
+
+static bool intercept_action(VMIntrospection *i,
+                             VMI_intercept_command action, Error **errp)
+{
+    if (i->intercepted_action != VMI_INTERCEPT_NONE) {
+        error_report("VMI: unhook in progress");
+        return false;
+    }
+
+    switch (action) {
+    case VMI_INTERCEPT_RESUME:
+        enable_socket_reconnect(i);
+        return false;
+    default:
+        break;
+    }
+
+    return vmi_maybe_wait_for_unhook(i, action);
+}
+
+bool vm_introspection_intercept(VMI_intercept_command action, Error **errp)
+{
+    VMIntrospection *i = vm_introspection_object();
+    bool intercepted = false;
+
+    if (record_intercept_action(action)) {
+        info_report("VMI: intercept command: %s", action_string[action]);
+
+        intercepted = intercept_action(i, action, errp);
+
+        info_report("VMI: intercept action: %s",
+                    intercepted ? "delayed" : "continue");
+    }
+
+    return intercepted;
 }
 
 static bool make_cookie_hash(const char *key_id, uint8_t *cookie_hash,

--- a/accel/kvm/vmi.c
+++ b/accel/kvm/vmi.c
@@ -146,11 +146,19 @@ static void prop_set_uint32(Object *obj, Visitor *v, const char *name,
     }
 }
 
+static bool vmi_can_be_deleted(UserCreatable *uc)
+{
+    VMIntrospection *i = VM_INTROSPECTION(uc);
+
+    return !i->connected;
+}
+
 static void class_init(ObjectClass *oc, void *data)
 {
     UserCreatableClass *uc = USER_CREATABLE_CLASS(oc);
 
     uc->complete = vmi_complete;
+    uc->can_be_deleted = vmi_can_be_deleted;
 }
 
 static void instance_init(Object *obj)

--- a/accel/kvm/vmi.c
+++ b/accel/kvm/vmi.c
@@ -52,10 +52,18 @@ typedef struct VMIntrospection {
     bool kvmi_hooked;
 } VMIntrospection;
 
+typedef struct VMIntrospectionClass {
+    ObjectClass parent_class;
+    uint32_t instance_counter;
+    VMIntrospection *uniq;
+} VMIntrospectionClass;
+
 #define TYPE_VM_INTROSPECTION "introspection"
 
 #define VM_INTROSPECTION(obj) \
     OBJECT_CHECK(VMIntrospection, (obj), TYPE_VM_INTROSPECTION)
+#define VM_INTROSPECTION_CLASS(class) \
+    OBJECT_CLASS_CHECK(VMIntrospectionClass, (class), TYPE_VM_INTROSPECTION)
 
 static Error *vm_introspection_init(VMIntrospection *i);
 
@@ -81,7 +89,13 @@ static void update_vm_start_time(VMIntrospection *i)
 
 static void vmi_complete(UserCreatable *uc, Error **errp)
 {
+    VMIntrospectionClass *ic = VM_INTROSPECTION_CLASS(OBJECT(uc)->class);
     VMIntrospection *i = VM_INTROSPECTION(uc);
+
+    if (ic->instance_counter > 1) {
+        error_setg(errp, "VMI: only one introspection object can be created");
+        return;
+    }
 
     if (!i->chardevid) {
         error_setg(errp, "VMI: chardev is not set");
@@ -106,6 +120,8 @@ static void vmi_complete(UserCreatable *uc, Error **errp)
         i->init_error = NULL;
         return;
     }
+
+    ic->uniq = i;
 
     update_vm_start_time(i);
 }
@@ -163,7 +179,10 @@ static void class_init(ObjectClass *oc, void *data)
 
 static void instance_init(Object *obj)
 {
+    VMIntrospectionClass *ic = VM_INTROSPECTION_CLASS(obj->class);
     VMIntrospection *i = VM_INTROSPECTION(obj);
+
+    ic->instance_counter++;
 
     i->created_from_command_line = (qdev_hotplug == false);
 
@@ -216,6 +235,7 @@ static void cancel_handshake_timer(VMIntrospection *i)
 
 static void instance_finalize(Object *obj)
 {
+    VMIntrospectionClass *ic = VM_INTROSPECTION_CLASS(obj->class);
     VMIntrospection *i = VM_INTROSPECTION(obj);
 
     g_free(i->chardevid);
@@ -228,12 +248,18 @@ static void instance_finalize(Object *obj)
     }
 
     error_free(i->init_error);
+
+    ic->instance_counter--;
+    if (!ic->instance_counter) {
+        ic->uniq = NULL;
+    }
 }
 
 static const TypeInfo info = {
     .name              = TYPE_VM_INTROSPECTION,
     .parent            = TYPE_OBJECT,
     .class_init        = class_init,
+    .class_size        = sizeof(VMIntrospectionClass),
     .instance_size     = sizeof(VMIntrospection),
     .instance_finalize = instance_finalize,
     .instance_init     = instance_init,

--- a/accel/stubs/Makefile.objs
+++ b/accel/stubs/Makefile.objs
@@ -2,4 +2,5 @@ obj-$(call lnot,$(CONFIG_HAX))  += hax-stub.o
 obj-$(call lnot,$(CONFIG_HVF))  += hvf-stub.o
 obj-$(call lnot,$(CONFIG_WHPX)) += whpx-stub.o
 obj-$(call lnot,$(CONFIG_KVM))  += kvm-stub.o
+obj-$(call lnot,$(CONFIG_KVM))  += vmi-stubs.o
 obj-$(call lnot,$(CONFIG_TCG))  += tcg-stub.o

--- a/accel/stubs/vmi-stubs.c
+++ b/accel/stubs/vmi-stubs.c
@@ -1,0 +1,7 @@
+#include "qemu/osdep.h"
+#include "sysemu/vmi-intercept.h"
+
+bool vm_introspection_intercept(VMI_intercept_command ic, Error **errp)
+{
+    return false;
+}

--- a/backends/Makefile.objs
+++ b/backends/Makefile.objs
@@ -17,3 +17,4 @@ endif
 common-obj-$(call land,$(CONFIG_VHOST_USER),$(CONFIG_VIRTIO)) += vhost-user.o
 
 common-obj-$(CONFIG_LINUX) += hostmem-memfd.o
+common-obj-$(CONFIG_LINUX) += hostmem-remmap.o

--- a/backends/hostmem-remmap.c
+++ b/backends/hostmem-remmap.c
@@ -1,0 +1,278 @@
+/*
+ * QEMU host fd memory backend
+ *
+ * Copyright (C) 2020 Bitdefender S.R.L.
+ *
+ * Authors:
+ *   Mircea Cirjaliu <mcirjaliu@bitdefender.com>
+ *
+ * This work is licensed under the terms of the GNU GPL, version 2 or later.
+ * See the COPYING file in the top-level directory.
+ */
+#include "qemu/osdep.h"
+#include "qemu-common.h"
+#include "sysemu/hostmem-remmap.h"
+#include "sysemu/sysemu.h"
+#include "qom/object_interfaces.h"
+#include "qemu/memfd.h"
+#include "qapi/error.h"
+#include "qemu/error-report.h"
+
+#include <linux/remote_mapping.h>
+#include <sys/ioctl.h>
+
+#define MB (1024 * 1024)
+
+void remote_memory_backend_remap(HostMemoryBackendRM *m, Error **errp)
+{
+    HostMemoryBackend *backend = MEMORY_BACKEND(m);
+    int result;
+    void *repl;
+
+    result = ioctl(m->fd, PIDFD_MEM_REMAP, m->hotplug_ptr);
+    if (result) {
+        error_setg_errno(errp, errno, "Remapping failed for %lx", m->offset);
+
+        if (!m->replaced) {
+            /* replace useful memory with anon memory */
+            munmap(m->hotplug_ptr, backend->size);
+            repl = mmap(m->hotplug_ptr, backend->size, PROT_READ,
+                        MAP_ANONYMOUS | MAP_PRIVATE | MAP_FIXED, -1, 0);
+            if (repl == MAP_FAILED) {
+                warn_report("%s: replacing useful memory failed", __func__);
+            }
+            /* no specific action taken if mmap() failed */
+
+            m->replaced = true;
+        }
+    }
+}
+
+static void
+rm_backend_memory_alloc(HostMemoryBackend *backend, Error **errp)
+{
+    HostMemoryBackendRM *m = MEMORY_BACKEND_RM(backend);
+    char *name;
+
+    if (!backend->size) {
+        error_setg(errp, "can't create backend with size 0");
+        return;
+    }
+
+    if (m->fd == -1) {
+        error_setg(errp, "can't create backend with fd -1");
+        return;
+    }
+
+    if (host_memory_backend_mr_inited(backend)) {
+        return;
+    }
+
+    backend->force_prealloc = mem_prealloc;
+
+    // remote mapping may impose certain size/alignment constraints not compatible with memory hotplug
+    // the hotpluggable region must be of size 2^x, bigger than the remote mapped region
+    // first the backing memory must be allocated so the region is reserved
+    // then the useful memory can start at any alignment [0, 2M) depending on the source VMA
+    // m->align gives the machine physical memory alignment (not related to remote mapping)
+
+    //         |<-----------useful size------------->|
+    // |-------|++++++++++++++++++++++++++++++++++++++........|-----------|
+    // |<----->|    alignment imposed by remote mapping
+    //         |<---------------pow2 size-------------------->|
+    // |<--------------------pow2 size + 2M------------------------------>|
+
+    m->hotplug_size = MAX(pow2ceil(backend->size), m->align);
+    m->mem_size = m->hotplug_size + 2 * MB;
+
+    /* alloc backing memory */
+    m->mem_ptr = mmap(0, m->mem_size, PROT_NONE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+    if (m->mem_ptr == MAP_FAILED) {
+        error_setg_errno(errp, errno, "%s: failed mapping %ld bytes", __func__, m->mem_size);
+        return;
+    }
+
+    /* map remote memory */
+    m->hotplug_ptr = mmap(m->mem_ptr, backend->size, PROT_READ | PROT_WRITE,
+        MAP_SHARED, m->fd, m->offset);
+    if (m->hotplug_ptr == MAP_FAILED) {
+        error_setg_errno(errp, errno, "%s: failed mapping %ld bytes", __func__, backend->size);
+        munmap(m->mem_ptr, m->mem_size);
+    }
+
+    name = g_strdup_printf("remote-map-%p", backend);
+    memory_region_init_ram_ptr(&backend->mr, OBJECT(backend), name,
+                               m->hotplug_size, m->hotplug_ptr);
+    backend->mr.align = m->align;
+    g_free(name);
+}
+
+static void
+rm_backend_get_fd(Object *obj, Visitor *v, const char *name,
+                  void *opaque, Error **errp)
+{
+    HostMemoryBackendRM *m = MEMORY_BACKEND_RM(obj);
+    uint64_t value = m->fd;
+
+    visit_type_size(v, name, &value, errp);
+}
+
+static void
+rm_backend_set_fd(Object *obj, Visitor *v, const char *name,
+                  void *opaque, Error **errp)
+{
+    HostMemoryBackendRM *m = MEMORY_BACKEND_RM(obj);
+    Error *local_err = NULL;
+    uint64_t value;
+
+    if (host_memory_backend_mr_inited(MEMORY_BACKEND(obj))) {
+        error_setg(&local_err, "cannot change property value");
+        goto out;
+    }
+
+    visit_type_size(v, name, &value, &local_err);
+    if (local_err) {
+        goto out;
+    }
+    if (!value) {
+        error_setg(&local_err, "Property '%s.%s' doesn't take value '%"
+            PRIu64 "'", object_get_typename(obj), name, value);
+        goto out;
+    }
+    m->fd = value;
+
+out:
+    error_propagate(errp, local_err);
+}
+
+static void
+rm_backend_get_offset(Object *obj, Visitor *v, const char *name,
+                      void *opaque, Error **errp)
+{
+    HostMemoryBackendRM *m = MEMORY_BACKEND_RM(obj);
+    uint64_t value = m->offset;
+
+    visit_type_size(v, name, &value, errp);
+}
+
+static void
+rm_backend_set_offset(Object *obj, Visitor *v, const char *name,
+                      void *opaque, Error **errp)
+{
+    HostMemoryBackendRM *m = MEMORY_BACKEND_RM(obj);
+    Error *local_err = NULL;
+    uint64_t value;
+
+    if (host_memory_backend_mr_inited(MEMORY_BACKEND(obj))) {
+        error_setg(&local_err, "cannot change property value");
+        goto out;
+    }
+
+    visit_type_size(v, name, &value, &local_err);
+    if (local_err) {
+        goto out;
+    }
+    m->offset = value;
+
+out:
+    error_propagate(errp, local_err);
+}
+
+static void
+rm_backend_get_align(Object *obj, Visitor *v, const char *name,
+                     void *opaque, Error **errp)
+{
+    HostMemoryBackendRM *m = MEMORY_BACKEND_RM(obj);
+    uint64_t val = m->align;
+
+    visit_type_size(v, name, &val, errp);
+}
+
+static void
+rm_backend_set_align(Object *obj, Visitor *v, const char *name,
+                     void *opaque, Error **errp)
+{
+    HostMemoryBackendRM *m = MEMORY_BACKEND_RM(obj);
+    Error *local_err = NULL;
+    uint64_t value;
+
+    if (host_memory_backend_mr_inited(MEMORY_BACKEND(obj))) {
+        error_setg(&local_err, "cannot change property value");
+        goto out;
+    }
+
+    visit_type_size(v, name, &value, &local_err);
+    if (local_err) {
+        goto out;
+    }
+    if (!value) {
+        error_setg(&local_err, "Property '%s.%s' doesn't take value '%"
+            PRIu64 "'", object_get_typename(obj), name, value);
+        goto out;
+    }
+    m->align = value;
+
+out:
+    error_propagate(errp, local_err);
+}
+
+static void
+rm_backend_instance_init(Object *obj)
+{
+    HostMemoryBackendRM *m = MEMORY_BACKEND_RM(obj);
+
+    m->fd = -1;
+}
+
+static void
+rm_backend_instance_finalize(Object *obj)
+{
+    HostMemoryBackendRM *m = MEMORY_BACKEND_RM(obj);
+
+    info_report("%s: fd %d, offset %lx, size %lx",
+        __func__, m->fd, m->offset, MEMORY_BACKEND(obj)->size);
+
+    if (m->mem_ptr) {
+        /* munmap useful & backing memory */
+        munmap(m->mem_ptr, m->mem_size);
+    }
+}
+
+static void
+rm_backend_class_init(ObjectClass *oc, void *data)
+{
+    HostMemoryBackendClass *bc = MEMORY_BACKEND_CLASS(oc);
+
+    bc->alloc = rm_backend_memory_alloc;
+
+    object_class_property_add(oc, "fd", "int",
+        rm_backend_get_fd,
+        rm_backend_set_fd,
+        NULL, NULL, &error_abort);
+
+    object_class_property_add(oc, "offset", "int",
+        rm_backend_get_offset,
+        rm_backend_set_offset,
+        NULL, NULL, &error_abort);
+
+    object_class_property_add(oc, "align", "int",
+        rm_backend_get_align,
+        rm_backend_set_align,
+        NULL, NULL, &error_abort);
+}
+
+static const TypeInfo rm_backend_info = {
+    .name = TYPE_MEMORY_BACKEND_RM,
+    .parent = TYPE_MEMORY_BACKEND,
+    .class_init = rm_backend_class_init,
+    .instance_init = rm_backend_instance_init,
+    .instance_finalize = rm_backend_instance_finalize,
+    .instance_size = sizeof(HostMemoryBackendRM),
+};
+
+static void register_types(void)
+{
+    type_register_static(&rm_backend_info);
+}
+
+type_init(register_types);

--- a/chardev/char-fe.c
+++ b/chardev/char-fe.c
@@ -384,3 +384,14 @@ void qemu_chr_fe_disconnect(CharBackend *be)
         CHARDEV_GET_CLASS(chr)->chr_disconnect(chr);
     }
 }
+
+int qemu_chr_fe_reconnect_time(CharBackend *be, int secs)
+{
+    Chardev *chr = be->chr;
+
+    if (chr && CHARDEV_GET_CLASS(chr)->chr_reconnect_time) {
+        return CHARDEV_GET_CLASS(chr)->chr_reconnect_time(chr, secs);
+    }
+
+    return -1;
+}

--- a/chardev/char-fe.c
+++ b/chardev/char-fe.c
@@ -317,6 +317,15 @@ void qemu_chr_fe_take_focus(CharBackend *b)
     }
 }
 
+void qemu_chr_fe_connect(CharBackend *be)
+{
+    Chardev *chr = be->chr;
+
+    if (chr && CHARDEV_GET_CLASS(chr)->chr_connect) {
+        CHARDEV_GET_CLASS(chr)->chr_connect(chr);
+    }
+}
+
 int qemu_chr_fe_wait_connected(CharBackend *be, Error **errp)
 {
     if (!be->chr) {

--- a/chardev/char-socket.c
+++ b/chardev/char-socket.c
@@ -1509,6 +1509,21 @@ char_socket_get_connected(Object *obj, Error **errp)
     return s->state == TCP_CHARDEV_STATE_CONNECTED;
 }
 
+static void
+char_socket_get_fd(Object *obj, Visitor *v, const char *name, void *opaque,
+                   Error **errp)
+{
+    int fd = -1;
+    SocketChardev *s = SOCKET_CHARDEV(obj);
+    QIOChannelSocket *sock = QIO_CHANNEL_SOCKET(s->sioc);
+
+    if (sock) {
+        fd = sock->fd;
+    }
+
+    visit_type_int32(v, name, &fd, errp);
+}
+
 static int tcp_chr_reconnect_time(Chardev *chr, int secs)
 {
     SocketChardev *s = SOCKET_CHARDEV(chr);
@@ -1546,6 +1561,9 @@ static void char_socket_class_init(ObjectClass *oc, void *data)
 
     object_class_property_add_bool(oc, "connected", char_socket_get_connected,
                                    NULL, &error_abort);
+
+    object_class_property_add(oc, "fd", "int32", char_socket_get_fd,
+                              NULL, NULL, NULL, &error_abort);
 }
 
 static const TypeInfo char_socket_type_info = {

--- a/chardev/char-socket.c
+++ b/chardev/char-socket.c
@@ -1471,6 +1471,19 @@ char_socket_get_connected(Object *obj, Error **errp)
     return s->state == TCP_CHARDEV_STATE_CONNECTED;
 }
 
+static int tcp_chr_reconnect_time(Chardev *chr, int secs)
+{
+    SocketChardev *s = SOCKET_CHARDEV(chr);
+
+    int old = s->reconnect_time;
+
+    if (secs >= 0) {
+        s->reconnect_time = secs;
+    }
+
+    return old;
+}
+
 static void char_socket_class_init(ObjectClass *oc, void *data)
 {
     ChardevClass *cc = CHARDEV_CLASS(oc);
@@ -1481,6 +1494,7 @@ static void char_socket_class_init(ObjectClass *oc, void *data)
     cc->chr_write = tcp_chr_write;
     cc->chr_sync_read = tcp_chr_sync_read;
     cc->chr_disconnect = tcp_chr_disconnect;
+    cc->chr_reconnect_time = tcp_chr_reconnect_time;
     cc->get_msgfds = tcp_get_msgfds;
     cc->set_msgfds = tcp_set_msgfds;
     cc->chr_add_client = tcp_chr_add_client;

--- a/chardev/char-socket.c
+++ b/chardev/char-socket.c
@@ -492,7 +492,7 @@ static void tcp_chr_disconnect_locked(Chardev *chr)
     if (emit_close) {
         qemu_chr_be_event(chr, CHR_EVENT_CLOSED);
     }
-    if (s->reconnect_time) {
+    if (s->reconnect_time && !s->reconnect_timer) {
         qemu_chr_socket_restart_timer(chr);
     }
 }

--- a/chardev/char-socket.c
+++ b/chardev/char-socket.c
@@ -23,6 +23,11 @@
  */
 
 #include "qemu/osdep.h"
+
+#ifdef CONFIG_AF_VSOCK
+#include <linux/vm_sockets.h>
+#endif /* CONFIG_AF_VSOCK */
+
 #include "chardev/char.h"
 #include "io/channel-socket.h"
 #include "io/channel-tls.h"
@@ -590,6 +595,14 @@ static char *qemu_chr_compute_filename(SocketChardev *s)
                                left, shost, right, sserv,
                                s->is_listen ? ",server" : "",
                                left, phost, right, pserv);
+
+#ifdef CONFIG_AF_VSOCK
+    case AF_VSOCK:
+        return g_strdup_printf("vsock:%d:%d%s",
+                               ((struct sockaddr_vm *)(ss))->svm_cid,
+                               ((struct sockaddr_vm *)(ss))->svm_port,
+                               s->is_listen ? ",server" : "");
+#endif
 
     default:
         return g_strdup_printf("unknown");
@@ -1393,18 +1406,19 @@ static void qemu_chr_parse_socket(QemuOpts *opts, ChardevBackend *backend,
 {
     const char *path = qemu_opt_get(opts, "path");
     const char *host = qemu_opt_get(opts, "host");
+    const char *cid  = qemu_opt_get(opts, "cid");
     const char *port = qemu_opt_get(opts, "port");
     const char *fd = qemu_opt_get(opts, "fd");
     SocketAddressLegacy *addr;
     ChardevSocket *sock;
 
-    if ((!!path + !!fd + !!host) != 1) {
+    if ((!!path + !!fd + !!host + !!cid) != 1) {
         error_setg(errp,
-                   "Exactly one of 'path', 'fd' or 'host' required");
+                   "Exactly one of 'path', 'fd', 'cid' or 'host' required");
         return;
     }
 
-    if (host && !port) {
+    if ((host || cid) && !port) {
         error_setg(errp, "chardev: socket: no port given");
         return;
     }
@@ -1460,6 +1474,13 @@ static void qemu_chr_parse_socket(QemuOpts *opts, ChardevBackend *backend,
             .ipv4 = qemu_opt_get_bool(opts, "ipv4", 0),
             .has_ipv6 = qemu_opt_get(opts, "ipv6"),
             .ipv6 = qemu_opt_get_bool(opts, "ipv6", 0),
+        };
+    } else if (cid) {
+        addr->type = SOCKET_ADDRESS_LEGACY_KIND_VSOCK;
+        addr->u.vsock.data = g_new0(VsockSocketAddress, 1);
+        *addr->u.vsock.data = (VsockSocketAddress) {
+            .cid  = g_strdup(cid),
+            .port = g_strdup(port),
         };
     } else if (fd) {
         addr->type = SOCKET_ADDRESS_LEGACY_KIND_FD;

--- a/chardev/char.c
+++ b/chardev/char.c
@@ -841,6 +841,9 @@ QemuOptsList qemu_chardev_opts = {
             .name = "host",
             .type = QEMU_OPT_STRING,
         },{
+            .name = "cid",
+            .type = QEMU_OPT_STRING,
+        },{
             .name = "port",
             .type = QEMU_OPT_STRING,
         },{

--- a/chardev/char.c
+++ b/chardev/char.c
@@ -927,6 +927,9 @@ QemuOptsList qemu_chardev_opts = {
         },{
             .name = "logappend",
             .type = QEMU_OPT_BOOL,
+        },{
+            .name = "disconnected",
+            .type = QEMU_OPT_BOOL,
         },
         { /* end of list */ }
     },

--- a/cpus.c
+++ b/cpus.c
@@ -1159,7 +1159,9 @@ static void sigbus_reraise(void)
 
 static void sigbus_handler(int n, siginfo_t *siginfo, void *ctx)
 {
-    if (siginfo->si_code != BUS_MCEERR_AO && siginfo->si_code != BUS_MCEERR_AR) {
+    if (siginfo->si_code != BUS_MCEERR_AO &&
+        siginfo->si_code != BUS_MCEERR_AR &&
+        siginfo->si_code != BUS_ADRERR) {
         sigbus_reraise();
     }
 

--- a/include/chardev/char-fe.h
+++ b/include/chardev/char-fe.h
@@ -128,6 +128,14 @@ void qemu_chr_fe_take_focus(CharBackend *b);
 void qemu_chr_fe_accept_input(CharBackend *be);
 
 /**
+ * qemu_chr_fe_connect:
+ *
+ * Connect a disconnected character backend.
+ * Without associated Chardev, do nothing.
+ */
+void qemu_chr_fe_connect(CharBackend *be);
+
+/**
  * qemu_chr_fe_disconnect:
  *
  * Close a fd accepted by character backend.

--- a/include/chardev/char-fe.h
+++ b/include/chardev/char-fe.h
@@ -136,6 +136,13 @@ void qemu_chr_fe_accept_input(CharBackend *be);
 void qemu_chr_fe_disconnect(CharBackend *be);
 
 /**
+ * qemu_chr_fe_reconnect_time:
+ *
+ * Change the reconnect time and return the old value.
+ */
+int qemu_chr_fe_reconnect_time(CharBackend *be, int secs);
+
+/**
  * qemu_chr_fe_wait_connected:
  *
  * Wait for characted backend to be connected, return < 0 on error or

--- a/include/chardev/char.h
+++ b/include/chardev/char.h
@@ -268,6 +268,7 @@ typedef struct ChardevClass {
     int (*get_msgfds)(Chardev *s, int* fds, int num);
     int (*set_msgfds)(Chardev *s, int *fds, int num);
     int (*chr_add_client)(Chardev *chr, int fd);
+    void (*chr_connect)(Chardev *chr);
     int (*chr_wait_connected)(Chardev *chr, Error **errp);
     void (*chr_disconnect)(Chardev *chr);
     int (*chr_reconnect_time)(Chardev *be, int secs);

--- a/include/chardev/char.h
+++ b/include/chardev/char.h
@@ -270,6 +270,7 @@ typedef struct ChardevClass {
     int (*chr_add_client)(Chardev *chr, int fd);
     int (*chr_wait_connected)(Chardev *chr, Error **errp);
     void (*chr_disconnect)(Chardev *chr);
+    int (*chr_reconnect_time)(Chardev *be, int secs);
     void (*chr_accept_input)(Chardev *chr);
     void (*chr_set_echo)(Chardev *chr, bool echo);
     void (*chr_set_fe_open)(Chardev *chr, int fe_open);

--- a/include/monitor/monitor.h
+++ b/include/monitor/monitor.h
@@ -42,5 +42,6 @@ int monitor_fdset_get_fd(int64_t fdset_id, int flags);
 int monitor_fdset_dup_fd_add(int64_t fdset_id, int dup_fd);
 void monitor_fdset_dup_fd_remove(int dup_fd);
 int64_t monitor_fdset_dup_fd_find(int dup_fd);
+void monitor_qmp_respond_later(void *_mon, QDict *rsp);
 
 #endif /* MONITOR_H */

--- a/include/qapi/error.h
+++ b/include/qapi/error.h
@@ -147,6 +147,11 @@ const char *error_get_pretty(const Error *err);
 ErrorClass error_get_class(const Error *err);
 
 /*
+ * Get @err's errno code.
+ */
+int error_get_errno(const Error *err);
+
+/*
  * Create a new error object and assign it to *@errp.
  * If @errp is NULL, the error is ignored.  Don't bother creating one
  * then.

--- a/include/qemu/uuid.h
+++ b/include/qemu/uuid.h
@@ -39,6 +39,12 @@ typedef struct {
                  "%02hhx%02hhx-" \
                  "%02hhx%02hhx%02hhx%02hhx%02hhx%02hhx"
 
+#define UUID_ARG(uuid) \
+    (uuid)->data[0], (uuid)->data[1], (uuid)->data[2], (uuid)->data[3], \
+    (uuid)->data[4], (uuid)->data[5], (uuid)->data[6], (uuid)->data[7], \
+    (uuid)->data[8], (uuid)->data[9], (uuid)->data[10], (uuid)->data[11], \
+    (uuid)->data[12], (uuid)->data[13], (uuid)->data[14], (uuid)->data[15]
+
 #define UUID_FMT_LEN 36
 
 #define UUID_NONE "00000000-0000-0000-0000-000000000000"
@@ -56,5 +62,7 @@ char *qemu_uuid_unparse_strdup(const QemuUUID *uuid);
 int qemu_uuid_parse(const char *str, QemuUUID *uuid);
 
 QemuUUID qemu_uuid_bswap(QemuUUID uuid);
+
+QemuUUID *qemu_uuid_dup(const QemuUUID *uuid);
 
 #endif

--- a/include/sysemu/hostmem-remmap.h
+++ b/include/sysemu/hostmem-remmap.h
@@ -1,0 +1,43 @@
+/*
+ * QEMU Remote Memory Backend
+ *
+ * Copyright (C) 2020 Bitdefender S.R.L.
+ *
+ * Authors:
+ *   Mircea Cirjaliu <mcirjaliu@bitdefender.com>
+ *
+ * This work is licensed under the terms of the GNU GPL, version 2 or later.
+ * See the COPYING file in the top-level directory.
+ */
+
+#ifndef SYSEMU_HOSTMEM_REMMAP_H
+#define SYSEMU_HOSTMEM_REMMAP_H
+
+#include "sysemu/hostmem.h"
+
+#define TYPE_MEMORY_BACKEND_RM "memory-backend-remote-mapping"
+#define MEMORY_BACKEND_RM(obj)                                        \
+    OBJECT_CHECK(HostMemoryBackendRM, (obj), TYPE_MEMORY_BACKEND_RM)
+
+typedef struct HostMemoryBackendRM HostMemoryBackendRM;
+
+struct HostMemoryBackendRM {
+    HostMemoryBackend parent_obj;
+
+    int fd;
+    off_t offset;
+    uint64_t align;
+    bool replaced;
+
+    /* full memory */
+    size_t mem_size;
+    void *mem_ptr;
+
+    /* hotpluggable memory */
+    size_t hotplug_size;
+    void *hotplug_ptr;
+};
+
+void remote_memory_backend_remap(HostMemoryBackendRM *backend, Error **errp);
+
+#endif /* SYSEMU_HOSTMEM_REMMAP_H */

--- a/include/sysemu/kvm.h
+++ b/include/sysemu/kvm.h
@@ -475,6 +475,7 @@ void kvm_set_sigmask_len(KVMState *s, unsigned int sigmask_len);
 #if !defined(CONFIG_USER_ONLY)
 int kvm_physical_memory_addr_from_host(KVMState *s, void *ram_addr,
                                        hwaddr *phys_addr);
+hwaddr kvm_start_of_slot(KVMState *s, hwaddr phys_addr);
 #endif
 
 #endif /* NEED_CPU_H */

--- a/include/sysemu/vmi-handshake.h
+++ b/include/sysemu/vmi-handshake.h
@@ -1,0 +1,45 @@
+/*
+ * QEMU VM Introspection Handshake
+ *
+ */
+
+#ifndef QEMU_VMI_HANDSHAKE_H
+#define QEMU_VMI_HANDSHAKE_H
+
+enum { QEMU_VMI_NAME_SIZE = 64 };
+enum { QEMU_VMI_COOKIE_HASH_SIZE = 20};
+
+/**
+ * qemu_vmi_to_introspector:
+ *
+ * This structure is passed to the introspection tool during the handshake.
+ *
+ * @struct_size: the structure size
+ * @uuid: the UUID
+ * @start_time: the VM start time
+ * @name: the VM name
+ */
+typedef struct qemu_vmi_to_introspector {
+    uint32_t struct_size;
+    uint8_t  uuid[16];
+    uint32_t padding;
+    int64_t  start_time;
+    char     name[QEMU_VMI_NAME_SIZE];
+    /* ... */
+} qemu_vmi_to_introspector;
+
+/**
+ * qemu_vmi_from_introspector:
+ *
+ * This structure is passed by the introspection tool during the handshake.
+ *
+ * @struct_size: the structure size
+ * @cookie_hash: the hash of the cookie know by the introspection tool
+ */
+typedef struct qemu_vmi_from_introspector {
+    uint32_t struct_size;
+    uint8_t  cookie_hash[QEMU_VMI_COOKIE_HASH_SIZE];
+    /* ... */
+} qemu_vmi_from_introspector;
+
+#endif /* QEMU_VMI_HANDSHAKE_H */

--- a/include/sysemu/vmi-intercept.h
+++ b/include/sysemu/vmi-intercept.h
@@ -1,0 +1,21 @@
+/*
+ * QEMU VM Introspection
+ *
+ * Copyright (C) 2018-2020 Bitdefender S.R.L.
+ *
+ * This work is licensed under the terms of the GNU GPL, version 2 or later.
+ * See the COPYING file in the top-level directory.
+ */
+
+#ifndef QEMU_VMI_INTERCEPT_H
+#define QEMU_VMI_INTERCEPT_H
+
+typedef enum {
+    VMI_INTERCEPT_NONE = 0,
+    VMI_INTERCEPT_SUSPEND,
+    VMI_INTERCEPT_RESUME,
+} VMI_intercept_command;
+
+bool vm_introspection_intercept(VMI_intercept_command ic, Error **errp);
+
+#endif /* QEMU_VMI_INTERCEPT_H */

--- a/include/sysemu/vmi-intercept.h
+++ b/include/sysemu/vmi-intercept.h
@@ -10,6 +10,9 @@
 #ifndef QEMU_VMI_INTERCEPT_H
 #define QEMU_VMI_INTERCEPT_H
 
+#include "exec/hwaddr.h"
+#include <linux/kvm.h>
+
 typedef enum {
     VMI_INTERCEPT_NONE = 0,
     VMI_INTERCEPT_SUSPEND,
@@ -19,5 +22,9 @@ typedef enum {
 
 bool vm_introspection_intercept(VMI_intercept_command ic, Error **errp);
 bool vm_introspection_qmp_delay(void *mon, QDict *rsp);
+
+void vm_introspection_handle_exit(CPUState *cs,
+                                  struct kvm_introspection_exit *kvmi);
+bool vm_introspection_remap(CPUState *cs, hwaddr paddr);
 
 #endif /* QEMU_VMI_INTERCEPT_H */

--- a/include/sysemu/vmi-intercept.h
+++ b/include/sysemu/vmi-intercept.h
@@ -14,6 +14,7 @@ typedef enum {
     VMI_INTERCEPT_NONE = 0,
     VMI_INTERCEPT_SUSPEND,
     VMI_INTERCEPT_RESUME,
+    VMI_INTERCEPT_MIGRATE,
 } VMI_intercept_command;
 
 bool vm_introspection_intercept(VMI_intercept_command ic, Error **errp);

--- a/include/sysemu/vmi-intercept.h
+++ b/include/sysemu/vmi-intercept.h
@@ -18,5 +18,6 @@ typedef enum {
 } VMI_intercept_command;
 
 bool vm_introspection_intercept(VMI_intercept_command ic, Error **errp);
+bool vm_introspection_qmp_delay(void *mon, QDict *rsp);
 
 #endif /* QEMU_VMI_INTERCEPT_H */

--- a/linux-headers/asm-generic/unistd.h
+++ b/linux-headers/asm-generic/unistd.h
@@ -850,9 +850,11 @@ __SYSCALL(__NR_pidfd_open, sys_pidfd_open)
 #define __NR_clone3 435
 __SYSCALL(__NR_clone3, sys_clone3)
 #endif
+#define __NR_pidfd_mem 436
+__SYSCALL(__NR_pidfd_mem, sys_pidfd_mem)
 
 #undef __NR_syscalls
-#define __NR_syscalls 436
+#define __NR_syscalls 437
 
 /*
  * 32 bit systems traditionally used different

--- a/linux-headers/asm-x86/unistd_32.h
+++ b/linux-headers/asm-x86/unistd_32.h
@@ -426,5 +426,6 @@
 #define __NR_fspick 433
 #define __NR_pidfd_open 434
 #define __NR_clone3 435
+#define __NR_pidfd_mem 436
 
 #endif /* _ASM_X86_UNISTD_32_H */

--- a/linux-headers/asm-x86/unistd_64.h
+++ b/linux-headers/asm-x86/unistd_64.h
@@ -348,5 +348,6 @@
 #define __NR_fspick 433
 #define __NR_pidfd_open 434
 #define __NR_clone3 435
+#define __NR_pidfd_mem 436
 
 #endif /* _ASM_X86_UNISTD_64_H */

--- a/linux-headers/asm-x86/unistd_x32.h
+++ b/linux-headers/asm-x86/unistd_x32.h
@@ -301,6 +301,7 @@
 #define __NR_fspick (__X32_SYSCALL_BIT + 433)
 #define __NR_pidfd_open (__X32_SYSCALL_BIT + 434)
 #define __NR_clone3 (__X32_SYSCALL_BIT + 435)
+#define __NR_pidfd_mem (__X32_SYSCALL_BIT + 436)
 #define __NR_rt_sigaction (__X32_SYSCALL_BIT + 512)
 #define __NR_rt_sigreturn (__X32_SYSCALL_BIT + 513)
 #define __NR_ioctl (__X32_SYSCALL_BIT + 514)

--- a/linux-headers/linux/kvm.h
+++ b/linux-headers/linux/kvm.h
@@ -1577,18 +1577,18 @@ struct kvm_introspection_hook {
 	__u8 uuid[16];
 };
 
-#define KVM_INTROSPECTION_HOOK    _IOW(KVMIO, 0xc3, struct kvm_introspection_hook)
-#define KVM_INTROSPECTION_UNHOOK  _IO(KVMIO, 0xc4)
+#define KVM_INTROSPECTION_HOOK    _IOW(KVMIO, 0xff, struct kvm_introspection_hook)
+#define KVM_INTROSPECTION_UNHOOK  _IO(KVMIO, 0xfb)
 
 struct kvm_introspection_feature {
 	__u32 allow;
 	__s32 id;
 };
 
-#define KVM_INTROSPECTION_COMMAND _IOW(KVMIO, 0xc5, struct kvm_introspection_feature)
-#define KVM_INTROSPECTION_EVENT   _IOW(KVMIO, 0xc6, struct kvm_introspection_feature)
+#define KVM_INTROSPECTION_COMMAND _IOW(KVMIO, 0xfd, struct kvm_introspection_feature)
+#define KVM_INTROSPECTION_EVENT   _IOW(KVMIO, 0xfc, struct kvm_introspection_feature)
 
-#define KVM_INTROSPECTION_PREUNHOOK  _IO(KVMIO, 0xc7)
+#define KVM_INTROSPECTION_PREUNHOOK  _IO(KVMIO, 0xfe)
 
 #define KVM_INTROSPECTION_MAP     _IOW(KVMIO, 0xfa, __u64)
 

--- a/linux-headers/linux/kvm.h
+++ b/linux-headers/linux/kvm.h
@@ -204,6 +204,32 @@ struct kvm_hyperv_exit {
 	} u;
 };
 
+struct kvm_introspection_exit {
+#define KVM_EXIT_INTROSPECTION_START	1	/* domain introspection start */
+#define KVM_EXIT_INTROSPECTION_MAP	    2	/* mapping request */
+#define KVM_EXIT_INTROSPECTION_UNMAP	3	/* unmapping request */
+#define KVM_EXIT_INTROSPECTION_END	    4	/* domain introspection end */
+    __u64 type;	/* first! */
+    union {
+        struct {
+            __u8 uuid[16];  /* introspected domain UUID */
+        } kvmi_start;
+        struct {
+            __u8 uuid[16];  /* introspected domain UUID */
+            __u64 gpa;      /* introspected domain GPA */
+            __u64 len;      /* length of memory range */
+            __u64 min;      /* min length accepted for hotplug */
+        } kvmi_map;
+        struct {
+            __u8 uuid[16];  /* introspected domain UUID */
+            __u64 gpa;      /* local GPA */
+        } kvmi_unmap;
+        struct {
+            __u8 uuid[16];  /* introspected domain UUID */
+        } kvmi_end;
+    };
+};
+
 #define KVM_S390_GET_SKEYS_NONE   1
 #define KVM_S390_SKEYS_MAX        1048576
 
@@ -235,6 +261,7 @@ struct kvm_hyperv_exit {
 #define KVM_EXIT_S390_STSI        25
 #define KVM_EXIT_IOAPIC_EOI       26
 #define KVM_EXIT_HYPERV           27
+#define KVM_EXIT_INTROSPECTION    30
 
 /* For KVM_EXIT_INTERNAL_ERROR */
 /* Emulate instruction failed. */
@@ -394,6 +421,8 @@ struct kvm_run {
 		} eoi;
 		/* KVM_EXIT_HYPERV */
 		struct kvm_hyperv_exit hyperv;
+        /* KVM_EXIT_INTROSPECTION */
+        struct kvm_introspection_exit kvmi;
 		/* Fix the size of the union. */
 		char padding[256];
 	};
@@ -1560,6 +1589,8 @@ struct kvm_introspection_feature {
 #define KVM_INTROSPECTION_EVENT   _IOW(KVMIO, 0xc6, struct kvm_introspection_feature)
 
 #define KVM_INTROSPECTION_PREUNHOOK  _IO(KVMIO, 0xc7)
+
+#define KVM_INTROSPECTION_MAP     _IOW(KVMIO, 0xfa, __u64)
 
 #define KVM_DEV_ASSIGN_ENABLE_IOMMU	(1 << 0)
 #define KVM_DEV_ASSIGN_PCI_2_3		(1 << 1)

--- a/linux-headers/linux/kvm.h
+++ b/linux-headers/linux/kvm.h
@@ -1000,6 +1000,7 @@ struct kvm_ppc_resize_hpt {
 #define KVM_CAP_PMU_EVENT_FILTER 173
 #define KVM_CAP_ARM_IRQ_LINE_LAYOUT_2 174
 #define KVM_CAP_HYPERV_DIRECT_TLBFLUSH 175
+#define KVM_CAP_INTROSPECTION 180
 
 #ifdef KVM_CAP_IRQ_ROUTING
 
@@ -1540,6 +1541,25 @@ struct kvm_sev_dbg {
 	__u64 dst_uaddr;
 	__u32 len;
 };
+
+struct kvm_introspection_hook {
+	__s32 fd;
+	__u32 padding;
+	__u8 uuid[16];
+};
+
+#define KVM_INTROSPECTION_HOOK    _IOW(KVMIO, 0xc3, struct kvm_introspection_hook)
+#define KVM_INTROSPECTION_UNHOOK  _IO(KVMIO, 0xc4)
+
+struct kvm_introspection_feature {
+	__u32 allow;
+	__s32 id;
+};
+
+#define KVM_INTROSPECTION_COMMAND _IOW(KVMIO, 0xc5, struct kvm_introspection_feature)
+#define KVM_INTROSPECTION_EVENT   _IOW(KVMIO, 0xc6, struct kvm_introspection_feature)
+
+#define KVM_INTROSPECTION_PREUNHOOK  _IO(KVMIO, 0xc7)
 
 #define KVM_DEV_ASSIGN_ENABLE_IOMMU	(1 << 0)
 #define KVM_DEV_ASSIGN_PCI_2_3		(1 << 1)

--- a/linux-headers/linux/remote_mapping.h
+++ b/linux-headers/linux/remote_mapping.h
@@ -1,0 +1,39 @@
+/* SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note */
+
+#ifndef __UAPI_REMOTE_MAPPING_H__
+#define __UAPI_REMOTE_MAPPING_H__
+
+#include <linux/types.h>
+#include <linux/ioctl.h>
+
+// device file interface
+#define REMOTE_PROC_MAP	_IOW('r', 0x01, int)
+
+// system call interface
+struct rmemfds {
+    int32_t ctl_fd;
+    int32_t mem_fd;
+};
+
+// pidfd interface
+#define PIDFD_IO_MAGIC	'p'
+
+struct pidfd_mem_map {
+    uint64_t address;
+    uint64_t offset;
+    uint64_t size;
+};
+
+struct pidfd_mem_unmap {
+    uint64_t offset;
+    uint64_t size;
+};
+
+#define PIDFD_MEM_MAP	_IOW(PIDFD_IO_MAGIC, 0x01, struct pidfd_mem_map)
+#define PIDFD_MEM_UNMAP _IOW(PIDFD_IO_MAGIC, 0x02, struct pidfd_mem_unmap)
+#define PIDFD_MEM_LOCK	_IOW(PIDFD_IO_MAGIC, 0x03, int)
+
+#define PIDFD_MEM_REMAP _IOW(PIDFD_IO_MAGIC, 0x04, unsigned long)
+// TODO: actually this is not for pidfd, find better names
+
+#endif /* __UAPI_REMOTE_MAPPING_H__ */

--- a/monitor/qmp-cmds.c
+++ b/monitor/qmp-cmds.c
@@ -39,6 +39,8 @@
 #include "hw/mem/memory-device.h"
 #include "hw/acpi/acpi_dev_interface.h"
 
+#include "sysemu/vmi-intercept.h"
+
 NameInfo *qmp_query_name(Error **errp)
 {
     NameInfo *info = g_malloc0(sizeof(*info));
@@ -100,6 +102,9 @@ void qmp_stop(Error **errp)
     if (runstate_check(RUN_STATE_INMIGRATE)) {
         autostart = 0;
     } else {
+        if (vm_introspection_intercept(VMI_INTERCEPT_SUSPEND, errp)) {
+            return;
+        }
         vm_stop(RUN_STATE_PAUSED);
     }
 }
@@ -171,6 +176,11 @@ void qmp_cont(Error **errp)
         autostart = 1;
     } else {
         vm_start();
+        /*
+         * this interception is post-event as we might need the vm to run before
+         * doing the interception, therefore we do not need the return value.
+         */
+        vm_introspection_intercept(VMI_INTERCEPT_RESUME, errp);
     }
 }
 

--- a/monitor/qmp.c
+++ b/monitor/qmp.c
@@ -32,6 +32,7 @@
 #include "qapi/qmp/qjson.h"
 #include "qapi/qmp/qlist.h"
 #include "qapi/qmp/qstring.h"
+#include "sysemu/vmi-intercept.h"
 #include "trace.h"
 
 struct QMPRequest {
@@ -157,6 +158,16 @@ static void monitor_qmp_dispatch(MonitorQMP *mon, QObject *req)
                           " with 'qmp_capabilities'");
         }
     }
+
+    if (!vm_introspection_qmp_delay(mon, rsp)) {
+        monitor_qmp_respond(mon, rsp);
+        qobject_unref(rsp);
+    }
+}
+
+void monitor_qmp_respond_later(void *_mon, QDict *rsp)
+{
+    MonitorQMP *mon = _mon;
 
     monitor_qmp_respond(mon, rsp);
     qobject_unref(rsp);

--- a/monitor/stubs.c
+++ b/monitor/stubs.c
@@ -3,11 +3,6 @@
 
 #include "sysemu/vmi-intercept.h"
 
-bool vm_introspection_intercept(VMI_intercept_command ic, Error **errp)
-{
-    return false;
-}
-
 bool vm_introspection_qmp_delay(void *mon, QDict *rsp)
 {
     return false;

--- a/qapi/char.json
+++ b/qapi/char.json
@@ -263,6 +263,7 @@
 #          sockets (default: false) (Since: 2.10)
 # @websocket: enable websocket protocol on server
 #           sockets (default: false) (Since: 3.1)
+# @disconnected: do not attempt to connect on startup (default: false)
 # @reconnect: For a client socket, if a socket is disconnected,
 #          then attempt a reconnect after the given number of seconds.
 #          Setting this to zero disables this function. (default: 0)
@@ -280,6 +281,7 @@
             '*telnet': 'bool',
             '*tn3270': 'bool',
             '*websocket': 'bool',
+            '*disconnected': 'bool',
             '*reconnect': 'int' },
   'base': 'ChardevCommon' }
 

--- a/qemu-options.hx
+++ b/qemu-options.hx
@@ -4927,7 +4927,7 @@ CN=laptop.example.com,O=Example Home,L=London,ST=London,C=GB
 @end example
 
 
-@item -object introspection,id=@var{id},chardev=@var{id}[,key=@var{id}][,handshake_timeout=@var{seconds}][,unhook_timeout=@var{seconds}][,command=@var{id}[,...]][,event=@var{id}[,...]][,chardev-memintro=@var{id}]
+@item -object introspection,id=@var{id},chardev=@var{id}[,key=@var{id}][,handshake_timeout=@var{seconds}][,unhook_timeout=@var{seconds}][,command=@var{id}[,...]][,event=@var{id}[,...]][[,chardev-memintro=@var{id}]|[,chardev-memsrc=@var{id}]]
 
 Defines a VM Introspection (VMI) object that will connect to
 an introspection tool, initiate the handshake and hand over the connection
@@ -4968,6 +4968,12 @@ The @option{chardev-memintro} parameter provides the memory mapping
 channel for a VM running the introspection tool. This is the id of a
 previously created chardev socket. On this channel, the VM will accept
 memory mapping file descriptors from introspected VMs.
+
+The @option{chardev-memsrc} parameter provides the memory mapping
+channel for an introspected VM. This is the id of a previously created
+chardev socket. On this channel, the introspected VM will send two file
+descriptors that will be used by the introspection tool to map guest
+memory in its own process.
 
 VM introspected using a unix socket:
 @example
@@ -5021,6 +5027,16 @@ memory size no larger than 968GB (1000 - 32) at one time.
      -chardev socket,id=vmi_chardev,type=vsock,cid=1234,port=4321,reconnect=10
      -chardev socket,id=vmi_chardev_mem_intro,type=unix,path=/tmp/vmi-mem.sock,server=on,wait=off
      -object introspection,id=vmi,chardev=vmi_chardev,chardev-memintro=vmi_chardev_mem_intro
+
+@end example
+
+VM introspected with the memory mapping feature enabled:
+@example
+ # $QEMU \
+     ......
+     -chardev socket,id=vmi_chardev,type=unix,path=/tmp/vmi-guest1.sock,reconnect=10
+     -chardev socket,id=vmi_chardev_mem,type=unix,path=/tmp/vmi-mem.sock,disconnected
+     -object introspection,id=vmi,chardev=vmi_chardev,chardev-memsrc=vmi_chardev_mem
 
 @end example
 

--- a/target/i386/kvm.c
+++ b/target/i386/kvm.c
@@ -588,12 +588,19 @@ static void kvm_mce_inject(X86CPU *cpu, hwaddr paddr, int code)
     uint64_t mcg_status = MCG_STATUS_MCIP;
     int flags = 0;
 
-    if (code == BUS_MCEERR_AR) {
+    switch (code) {
+    case BUS_ADRERR:
+        mcg_status |= MCG_STATUS_RIPV;
+    case BUS_MCEERR_AR:
         status |= MCI_STATUS_AR | 0x134;
         mcg_status |= MCG_STATUS_EIPV;
-    } else {
+        break;
+    case BUS_MCEERR_AO:
         status |= 0xc0;
         mcg_status |= MCG_STATUS_RIPV;
+        break;
+    default:
+        assert(false);
     }
 
     flags = cpu_x86_support_mca_broadcast(env) ? MCE_INJECT_BROADCAST : 0;
@@ -622,13 +629,15 @@ void kvm_arch_on_sigbus_vcpu(CPUState *c, int code, void *addr)
     CPUX86State *env = &cpu->env;
     ram_addr_t ram_addr;
     hwaddr paddr;
+    const char *code_str;
 
     /* If we get an action required MCE, it has been injected by KVM
      * while the VM was running.  An action optional MCE instead should
      * be coming from the main thread, which qemu_init_sigbus identifies
      * as the "early kill" thread.
      */
-    assert(code == BUS_MCEERR_AR || code == BUS_MCEERR_AO);
+    assert(code == BUS_MCEERR_AR || code == BUS_MCEERR_AO ||
+           code == BUS_ADRERR);
 
     if ((env->mcg_cap & MCG_SER_P) && addr) {
         ram_addr = qemu_ram_addr_from_host(addr);
@@ -636,6 +645,24 @@ void kvm_arch_on_sigbus_vcpu(CPUState *c, int code, void *addr)
             kvm_physical_memory_addr_from_host(c->kvm_state, addr, &paddr)) {
             kvm_hwpoison_page_add(ram_addr);
             kvm_mce_inject(cpu, paddr, code);
+
+            switch (code) {
+            case BUS_MCEERR_AR:
+                code_str = "BUS_MCEERR_AR";
+                break;
+
+            case BUS_MCEERR_AO:
+                code_str = "BUS_MCEERR_AO";
+                break;
+
+            case BUS_ADRERR:
+                code_str = "BUS_ADRERR";
+                break;
+
+            default:
+                code_str = "<undefined>";
+                break;
+            }
 
             /*
              * Use different logging severity based on error type.
@@ -645,11 +672,11 @@ void kvm_arch_on_sigbus_vcpu(CPUState *c, int code, void *addr)
             if (code == BUS_MCEERR_AR) {
                 error_report("Guest MCE Memory Error at QEMU addr %p and "
                     "GUEST addr 0x%" HWADDR_PRIx " of type %s injected",
-                    addr, paddr, "BUS_MCEERR_AR");
+                    addr, paddr, code_str);
             } else {
                  warn_report("Guest MCE Memory Error at QEMU addr %p and "
                      "GUEST addr 0x%" HWADDR_PRIx " of type %s injected",
-                     addr, paddr, "BUS_MCEERR_AO");
+                     addr, paddr, code_str);
             }
 
             return;

--- a/util/uuid.c
+++ b/util/uuid.c
@@ -50,19 +50,12 @@ int qemu_uuid_is_equal(const QemuUUID *lhv, const QemuUUID *rhv)
 
 void qemu_uuid_unparse(const QemuUUID *uuid, char *out)
 {
-    const unsigned char *uu = &uuid->data[0];
-    snprintf(out, UUID_FMT_LEN + 1, UUID_FMT,
-             uu[0], uu[1], uu[2], uu[3], uu[4], uu[5], uu[6], uu[7],
-             uu[8], uu[9], uu[10], uu[11], uu[12], uu[13], uu[14], uu[15]);
+    snprintf(out, UUID_FMT_LEN + 1, UUID_FMT, UUID_ARG(uuid));
 }
 
 char *qemu_uuid_unparse_strdup(const QemuUUID *uuid)
 {
-    const unsigned char *uu = &uuid->data[0];
-    return g_strdup_printf(UUID_FMT,
-                           uu[0], uu[1], uu[2], uu[3], uu[4], uu[5], uu[6],
-                           uu[7], uu[8], uu[9], uu[10], uu[11], uu[12],
-                           uu[13], uu[14], uu[15]);
+    return g_strdup_printf(UUID_FMT, UUID_ARG(uuid));
 }
 
 static bool qemu_uuid_is_valid(const char *str)
@@ -115,4 +108,11 @@ QemuUUID qemu_uuid_bswap(QemuUUID uuid)
     bswap16s(&uuid.fields.time_mid);
     bswap16s(&uuid.fields.time_high_and_version);
     return uuid;
+}
+
+QemuUUID *qemu_uuid_dup(const QemuUUID *uuid)
+{
+    QemuUUID *ret = g_malloc(sizeof(QemuUUID));
+    memcpy(ret, uuid, sizeof(QemuUUID));
+    return ret;
 }


### PR DESCRIPTION
This VMI patchset is based on the upstream **v4.2.1** tag (your upstream remote is not up-to-date right now and I couldn't point the destination to v4.2.1).

The user-space part of the remote memory mapping feature (one process mapping memory pages from another process) is controlled through two new QEMU objects, transparently created by two new parameters of the introspection object: chardev-memsrc and chardev-memintro. See the usage examples at the end of the [qemu-options.hx](https://github.com/adlazar/qemu/blob/kvmi-v7/qemu-options.hx#L4409) file.

You'll see that the VM running the introspection app needs additional arguments. The libvirt equivalents are:

```
  <maxMemory slots='255' unit='GiB'>1000</maxMemory>
  <memory unit='GiB'>32</memory>
  <currentMemory unit='GiB'>32</currentMemory>
  <cpu><numa>
      <cell id='0' cpus='0-3' memory='32' unit='GiB'/>
  </numa></cpu>

```
The build should be compatible with the current kernel from [kvm-vmi/kvm:kvmi-v7](https://github.com/KVM-VMI/kvm/tree/kvmi-v7). If the kernel doesn't support the new remote memory mapping interface (syscall/ioctl), you'll only get a warning. But, to use the new interface, you'll need the latest patches from [adlazar/kvmi-v7++](https://github.com/adlazar/kvm/tree/kvmi-v7++) (I'll create a PR for this) and the latest version of the [bitdefender/libkvmi](https://github.com/bitdefender/libkvmi) library (1.0.0).