### PR TITLE
accel/kvm/vmi: avoid dereferencing a null pointer when the introspect…

### DIFF
--- a/accel/kvm/vmi.c
+++ b/accel/kvm/vmi.c
@@ -1011,7 +1011,7 @@ bool vm_introspection_intercept(VMI_intercept_command action, Error **errp)
     VMIntrospection *i = vm_introspection_object();
     bool intercepted = false;
 
-    if (record_intercept_action(action)) {
+    if (record_intercept_action(action) && i) {
         info_report("VMI: intercept command: %s", action_string[action]);
 
         intercepted = intercept_action(i, action, errp);


### PR DESCRIPTION
…ion object is not yet created

Link: https://github.com/KVM-VMI/qemu/issues/8
Signed-off-by: Adalbert Lazăr <alazar@bitdefender.com>