### PR TITLE
linux-headers: avoid clash of syscall index for pidfd_mem

### DIFF
--- a/linux-headers/asm-generic/unistd.h
+++ b/linux-headers/asm-generic/unistd.h
@@ -850,11 +850,11 @@ __SYSCALL(__NR_pidfd_open, sys_pidfd_open)
 #define __NR_clone3 435
 __SYSCALL(__NR_clone3, sys_clone3)
 #endif
-#define __NR_pidfd_mem 436
+#define __NR_pidfd_mem 999
 __SYSCALL(__NR_pidfd_mem, sys_pidfd_mem)
 
 #undef __NR_syscalls
-#define __NR_syscalls 437
+#define __NR_syscalls 1000
 
 /*
  * 32 bit systems traditionally used different

--- a/linux-headers/asm-x86/unistd_32.h
+++ b/linux-headers/asm-x86/unistd_32.h
@@ -426,6 +426,6 @@
 #define __NR_fspick 433
 #define __NR_pidfd_open 434
 #define __NR_clone3 435
-#define __NR_pidfd_mem 436
+#define __NR_pidfd_mem 999
 
 #endif /* _ASM_X86_UNISTD_32_H */

--- a/linux-headers/asm-x86/unistd_64.h
+++ b/linux-headers/asm-x86/unistd_64.h
@@ -348,6 +348,6 @@
 #define __NR_fspick 433
 #define __NR_pidfd_open 434
 #define __NR_clone3 435
-#define __NR_pidfd_mem 436
+#define __NR_pidfd_mem 999
 
 #endif /* _ASM_X86_UNISTD_64_H */

--- a/linux-headers/asm-x86/unistd_x32.h
+++ b/linux-headers/asm-x86/unistd_x32.h
@@ -301,7 +301,6 @@
 #define __NR_fspick (__X32_SYSCALL_BIT + 433)
 #define __NR_pidfd_open (__X32_SYSCALL_BIT + 434)
 #define __NR_clone3 (__X32_SYSCALL_BIT + 435)
-#define __NR_pidfd_mem (__X32_SYSCALL_BIT + 436)
 #define __NR_rt_sigaction (__X32_SYSCALL_BIT + 512)
 #define __NR_rt_sigreturn (__X32_SYSCALL_BIT + 513)
 #define __NR_ioctl (__X32_SYSCALL_BIT + 514)
@@ -338,5 +337,6 @@
 #define __NR_execveat (__X32_SYSCALL_BIT + 545)
 #define __NR_preadv2 (__X32_SYSCALL_BIT + 546)
 #define __NR_pwritev2 (__X32_SYSCALL_BIT + 547)
+#define __NR_pidfd_mem (__X32_SYSCALL_BIT + 999)
 
 #endif /* _ASM_X86_UNISTD_X32_H */


### PR DESCRIPTION
The mem-introspection feature uses the pidfd_mem syscall, which clashed with close_range in Linux 5.9.
To avoid issues with other software, the syscall index is shifted in the kernel (https://github.com/KVM-VMI/kvm/pull/49).

This pull requests adjusts the syscall index in the user mode component.