### PR TITLE
vmi: fix the start_time field sent during the handshake

### DIFF
--- a/accel/kvm/vmi.c
+++ b/accel/kvm/vmi.c
@@ -165,7 +165,7 @@ static void vmi_shutdown_notify(Notifier *notifier, void *data)
 
 static void update_vm_start_time(VMIntrospection *i)
 {
-    i->vm_start_time = qemu_clock_get_ms(QEMU_CLOCK_REALTIME) / 1000;
+    i->vm_start_time = qemu_clock_get_ms(QEMU_CLOCK_HOST) / 1000;
 }
 
 static void vmi_reset(void *opaque)


### PR DESCRIPTION
The reason for this field was to detect guest OS sessions. It is saved
when the guest is suspended and reset when the guest reboots.

The main introspection connection can be re-established for several
reasons: the guest is restarted/paused/suspended, the introspection tool
is upgraded, etc.

By switching from QEMU_CLOCK_REALTIME(CLOCK_MONOTONIC if it is defined)
to QEMU_CLOCK_HOST we'll have a human-friendly value.

The risk of having an admin changing the system clock and
cause a collision for a guest is low enough, not to mention that
QEMU_CLOCK_REALTIME is not collision-free for our use cases (a rebooted
host might generated the same time-value for new and restored guests).

Signed-off-by: Adalbert Lazăr <alazar@bitdefender.com>