### PR TITLE
kvm: vmi: add KVM_INTROSPECTION_GFN

### DIFF
--- a/linux-headers/linux/kvm.h
+++ b/linux-headers/linux/kvm.h
@@ -1585,12 +1585,23 @@ struct kvm_introspection_feature {
 	__s32 id;
 };
 
+struct kvm_introspection_gfn {
+	__u64 ret;
+	__u64 gfn;
+};
+
+#define KVM_INTROSPECTION_GFN_REPLY_ABORT -1
+#define KVM_INTROSPECTION_GFN_REPLY_WAIT   0
+#define KVM_INTROSPECTION_GFN_REPLY_ALLOC  1
+#define KVM_INTROSPECTION_GFN_REPLY_FREE   2
+
 #define KVM_INTROSPECTION_COMMAND _IOW(KVMIO, 0xfd, struct kvm_introspection_feature)
 #define KVM_INTROSPECTION_EVENT   _IOW(KVMIO, 0xfc, struct kvm_introspection_feature)
 
 #define KVM_INTROSPECTION_PREUNHOOK  _IO(KVMIO, 0xfe)
 
 #define KVM_INTROSPECTION_MAP     _IOW(KVMIO, 0xfa, __u64)
+#define KVM_INTROSPECTION_GFN     _IOW(KVMIO, 0xf9, struct kvm_introspection_gfn)
 
 #define KVM_DEV_ASSIGN_ENABLE_IOMMU	(1 << 0)
 #define KVM_DEV_ASSIGN_PCI_2_3		(1 << 1)


### PR DESCRIPTION
This PR proposes a method to dynamically add hot-pluggable main memory to a virtual machine through the introspection API. The core use case of such functionality is the runtime allocation of shadow pages with Intel EPT for code-hiding purposes [1].

The implementation of such functionality in the current KVMi architecture is not perfectly trivial because QEMU is responsible for allocating memory for the virtual machine, yet the introspection tool only communicates with KVM following the initial handshake. Another difficulty is the asynchronous nature of the API since the introspection tool may request more memory in response to some guest internal event. In that case, the execution context must remain intact such that the introspection tool can perform multiple actions before resuming the execution of the guest.

Our approach proposes a polling ioctl combined with threading for this purpose. See below for a short visualization of the proposed interactions:
```
gfn-thread : KVM_INTROSPECTION_GFN -->-----------op-----------|-> KVM_INTROSPECTION_GFN -->-----------op----------|-> ---- ....
                                     Ʌ                        V                           Ʌ                       V            
recv-thread: ------------------------|-> KVMI_VCPU_ALLOC_GFN -----------------------------|-> KVMI_VCPU_FREE_GFN --------- ....
```

Best,
Thomas

[1] http://phrack.org/issues/69/15.html